### PR TITLE
fix: fixed broken code due to methods renaming

### DIFF
--- a/review/src/main/kotlin/br/all/application/protocol/repository/ProtocolMapper.kt
+++ b/review/src/main/kotlin/br/all/application/protocol/repository/ProtocolMapper.kt
@@ -2,6 +2,7 @@ package br.all.application.protocol.repository
 
 import br.all.application.protocol.create.CreateProtocolService.RequestModel
 import br.all.domain.model.protocol.*
+import br.all.domain.model.protocol.Criterion.CriterionType
 import br.all.domain.model.review.SystematicStudyId
 import br.all.domain.shared.valueobject.Language
 import br.all.domain.shared.valueobject.Language.LangType
@@ -57,7 +58,7 @@ fun Protocol.Companion.fromRequestModel(request: RequestModel) = with(request) {
 }
 
 fun Protocol.Companion.fromDto(dto: ProtocolDto) = with(dto) {
-    Protocol.with(SystematicStudyId(systematicStudy), keywords)
+    write(SystematicStudyId(systematicStudy), keywords)
         .researchesFor(goal)
         .because(justification)
         .toAnswer(researchQuestions.map { ResearchQuestion(it) }.toSet())
@@ -65,10 +66,11 @@ fun Protocol.Companion.fromDto(dto: ProtocolDto) = with(dto) {
         .inSearchSources( informationSources.map { SearchSource(it) }.toSet()).selectedBecause(sourcesSelectionCriteria)
         .searchingStudiesIn( studiesLanguages.map { Language(Language.LangType.valueOf(it)) }.toSet(),studyTypeDefinition)
         .followingSelectionProcess(selectionProcess)
-        .withElegibilityCriteria(
+        .withEligibilityCriteria(
             selectionCriteria
-                .map { (description, type) -> Criteria(description, CriteriaType.valueOf(type)) }
-                .toSet())
+                .map { (description, type) -> Criterion(description, CriterionType.valueOf(type)) }
+                .toSet(),
+        )
         .followingDataCollectionProcess(dataCollectionProcess)
         .followingSynthesisProcess(analysisAndSynthesisProcess)
         .withPICOC(picoc?.let { Picoc(it.population, it.intervention, it.control, it.outcome, it.context) })

--- a/review/src/main/kotlin/br/all/application/protocol/repository/ProtocolRepository.kt
+++ b/review/src/main/kotlin/br/all/application/protocol/repository/ProtocolRepository.kt
@@ -7,8 +7,4 @@ interface ProtocolRepository {
     fun findById(id: UUID): ProtocolDto?
 
     fun existsById(id: UUID): Boolean
-
-    fun existsBySystematicStudy(systematicStudyId: UUID): Boolean
-
-    fun belongsToSystematicStudy(protocolId: UUID, systematicStudyId: UUID): Boolean
 }

--- a/review/src/main/kotlin/br/all/application/shared/presenter/PreconditionChecker.kt
+++ b/review/src/main/kotlin/br/all/application/shared/presenter/PreconditionChecker.kt
@@ -1,12 +1,10 @@
 package br.all.application.shared.presenter
 
-import br.all.application.protocol.repository.ProtocolRepository
 import br.all.application.researcher.credentials.ResearcherCredentialsService
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.shared.exceptions.EntityNotFoundException
 import br.all.application.shared.exceptions.UnauthenticatedUserException
 import br.all.application.shared.exceptions.UnauthorizedUserException
-import br.all.domain.model.protocol.ProtocolId
 import br.all.domain.model.researcher.ResearcherId
 import br.all.domain.model.review.SystematicStudyId
 
@@ -36,23 +34,5 @@ class PreconditionChecker(
             presenter.prepareFailView(UnauthorizedUserException("User of id $researcherId is not authorized."))
             return
         }
-    }
-
-    fun prepareIfViolatesPreconditions(
-        presenter: GenericPresenter<*>,
-        researcherId: ResearcherId,
-        systematicStudyId: SystematicStudyId,
-        protocolId: ProtocolId,
-        protocolRepository: ProtocolRepository,
-    ) {
-        prepareIfViolatesPreconditions(presenter, researcherId, systematicStudyId)
-        if (presenter.isDone()) return
-
-        if(!protocolRepository.existsById(protocolId.value())) {
-            presenter.prepareFailView(EntityNotFoundException("Protocol with id $protocolId does not exist!"))
-            return
-        }
-        if (!protocolRepository.belongsToSystematicStudy(protocolId.value(), systematicStudyId.value()))
-            presenter.prepareFailView(IllegalStateException("Protocol $protocolId does not belongs to study $systematicStudyId"))
     }
 }

--- a/review/src/main/kotlin/br/all/domain/model/question/LabeledScale.kt
+++ b/review/src/main/kotlin/br/all/domain/model/question/LabeledScale.kt
@@ -1,10 +1,9 @@
 package br.all.domain.model.question
 
-import br.all.domain.model.protocol.ProtocolId
 import br.all.domain.model.review.SystematicStudyId
 import br.all.domain.model.study.Answer
 import br.all.domain.shared.ddd.Notification
-import br.all.domain.shared.utils.requireThatExists
+import br.all.domain.shared.utils.exists
 
 class LabeledScale(
     id: QuestionId,
@@ -36,7 +35,7 @@ class LabeledScale(
     fun addScale(name: String, value: Int) = run { _scales[name] = Label(name, value) }
 
     fun removeScale(name: String) {
-        requireThatExists(name in _scales.keys) { "There is not a scale with name $name in this question!" }
+        exists(name in _scales.keys) { "There is not a scale with name $name in this question!" }
         check(_scales.size > 1) { "Unable to remove the last scale from this question!" }
         _scales.remove(name)
     }

--- a/review/src/main/kotlin/br/all/infrastructure/question/factory/LabeledScaleQuestionFactory.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/question/factory/LabeledScaleQuestionFactory.kt
@@ -3,7 +3,6 @@ package br.all.infrastructure.question.factory
 import br.all.application.question.create.CreateQuestionService
 import br.all.application.question.repository.QuestionDto
 import br.all.application.question.shared.QuestionFactory
-import br.all.domain.model.protocol.ProtocolId
 import br.all.domain.model.question.LabeledScale
 import br.all.domain.model.question.Question
 import br.all.domain.model.question.QuestionBuilder
@@ -21,7 +20,7 @@ class LabeledScaleQuestionFactory(private val mongoRepository: MongoQuestionRepo
     }
 
     override fun toDto(question: Question<*>) = with(question as LabeledScale){
-        QuestionDto(id.value(), systematicStudyId.value, code, description, "LabeledScale", scales = scales.mapValues { it.value.value })
+        QuestionDto(id.value(), systematicStudyId.value(), code, description, "LabeledScale", scales = scales.mapValues { it.value.value })
     }
 
     override fun repository() = QuestionRepositoryImpl(mongoRepository)

--- a/review/src/main/kotlin/br/all/infrastructure/question/factory/NumberScaleQuestionFactory.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/question/factory/NumberScaleQuestionFactory.kt
@@ -3,7 +3,6 @@ package br.all.infrastructure.question.factory
 import br.all.application.question.create.CreateQuestionService
 import br.all.application.question.repository.QuestionDto
 import br.all.application.question.shared.QuestionFactory
-import br.all.domain.model.protocol.ProtocolId
 import br.all.domain.model.question.NumberScale
 import br.all.domain.model.question.Question
 import br.all.domain.model.question.QuestionBuilder
@@ -21,7 +20,7 @@ class NumberScaleQuestionFactory(private val mongoRepository: MongoQuestionRepos
     }
 
     override fun toDto(question: Question<*>) = with(question as NumberScale){
-        QuestionDto(id.value(), systematicStudyId.value, code, description, "NumberScale", lower = lower, higher = higher)
+        QuestionDto(id.value(), systematicStudyId.value(), code, description, "NumberScale", lower = lower, higher = higher)
     }
 
     override fun repository() = QuestionRepositoryImpl(mongoRepository)

--- a/review/src/main/kotlin/br/all/infrastructure/question/factory/PickListQuestionFactory.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/question/factory/PickListQuestionFactory.kt
@@ -3,7 +3,6 @@ package br.all.infrastructure.question.factory
 import br.all.application.question.create.CreateQuestionService.RequestModel
 import br.all.application.question.repository.QuestionDto
 import br.all.application.question.shared.QuestionFactory
-import br.all.domain.model.protocol.ProtocolId
 import br.all.domain.model.question.PickList
 import br.all.domain.model.question.Question
 import br.all.domain.model.question.QuestionBuilder
@@ -21,7 +20,7 @@ class PickListQuestionFactory(private val mongoRepository: MongoQuestionReposito
     }
 
     override fun toDto(question: Question<*>) = with(question as PickList) {
-        QuestionDto(id.value(), systematicStudyId.value, code, description, "PickList", options = options)
+        QuestionDto(id.value(), systematicStudyId.value(), code, description, "PickList", options = options)
     }
 
     override fun repository() = QuestionRepositoryImpl(mongoRepository)


### PR DESCRIPTION
There were some broken code caused by merging branches with old function names. The function "requireThatExists()" was renamed to "exists()", but it was missing some places that used the old name. Also, there were methods defined in ProtocolRepository that are not going to be implemented or used anymore as well as the precondition checker method that was using them.