### PR TITLE
refactor duplicate study request model

### DIFF
--- a/web/src/main/kotlin/br/all/study/controller/StudyReviewController.kt
+++ b/web/src/main/kotlin/br/all/study/controller/StudyReviewController.kt
@@ -10,10 +10,7 @@ import br.all.application.study.update.interfaces.MarkAsDuplicatedService
 import br.all.application.study.update.interfaces.UpdateStudyReviewService
 import br.all.security.service.AuthenticationInfoService
 import br.all.study.presenter.*
-import br.all.study.requests.PatchRiskOfBiasAnswerStudyReviewRequest
-import br.all.study.requests.PatchStatusStudyReviewRequest
-import br.all.study.requests.PostStudyReviewRequest
-import br.all.study.requests.PutStudyReviewRequest
+import br.all.study.requests.*
 import br.all.utils.LinksFactory
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -443,13 +440,12 @@ class StudyReviewController(
     fun markAsDuplicated(
         @PathVariable systematicStudy: UUID,
         @PathVariable referenceStudyId: Long,
-        @RequestBody duplicatedStudyIds: List<Long>
+        @RequestBody duplicatedRequest: PatchDuplicatedStudiesRequest
     ): ResponseEntity<*> {
         val presenter = RestfulMarkAsDuplicatedPresenter(linksFactory)
         val userId = authenticationInfoService.getAuthenticatedUserId()
-        val request = DuplicatedRequest(userId, systematicStudy, referenceStudyId, duplicatedStudyIds)
+        val request = duplicatedRequest.toRequestModel(userId, systematicStudy, referenceStudyId)
         markAsDuplicatedService.markAsDuplicated(presenter, request)
         return presenter.responseEntity ?: ResponseEntity<Void>(HttpStatus.INTERNAL_SERVER_ERROR)
     }
-
 }

--- a/web/src/main/kotlin/br/all/study/requests/PatchDuplicatedStudiesRequest.kt
+++ b/web/src/main/kotlin/br/all/study/requests/PatchDuplicatedStudiesRequest.kt
@@ -1,0 +1,16 @@
+package br.all.study.requests
+
+import br.all.application.study.update.interfaces.MarkAsDuplicatedService
+import java.util.*
+
+data class PatchDuplicatedStudiesRequest (
+    val duplicatedStudyIds: List<Long>,
+){
+    fun toRequestModel(userId: UUID, systematicStudyId: UUID, studyReviewId: Long)
+            = MarkAsDuplicatedService.RequestModel(
+        userId,
+        systematicStudyId,
+        studyReviewId,
+        duplicatedStudyIds
+    )
+}

--- a/web/src/main/kotlin/br/all/utils/LinksFactory.kt
+++ b/web/src/main/kotlin/br/all/utils/LinksFactory.kt
@@ -8,6 +8,7 @@ import br.all.review.controller.SystematicStudyController
 import br.all.review.requests.PostRequest
 import br.all.search.controller.SearchSessionController
 import br.all.study.controller.StudyReviewController
+import br.all.study.requests.PatchDuplicatedStudiesRequest
 import br.all.study.requests.PatchStatusStudyReviewRequest
 import br.all.study.requests.PostStudyReviewRequest
 import org.springframework.hateoas.Link
@@ -232,6 +233,12 @@ class LinksFactory {
 
     fun markStudyAsDuplicated(systematicStudyId: UUID, ): Link =
         linkTo<StudyReviewController> {
-            markAsDuplicated(systematicStudyId, referenceStudyId = 11111,duplicatedStudyIds = listOf(11111))
+            markAsDuplicated(
+                systematicStudyId,
+                referenceStudyId = 11111,
+                duplicatedRequest = PatchDuplicatedStudiesRequest(
+                    duplicatedStudyIds = listOf(222222)
+                )
+            )
         }.withRel("mark-studies-as-duplicated").withType("PATCH")
 }

--- a/web/src/test/kotlin/br/all/search/controller/SearchSessionControllerTest.kt
+++ b/web/src/test/kotlin/br/all/search/controller/SearchSessionControllerTest.kt
@@ -1,10 +1,6 @@
 package br.all.search.controller
 
-import br.all.application.protocol.repository.toDto
-import br.all.domain.model.protocol.Protocol
-import br.all.domain.model.review.toSystematicStudyId
 import br.all.infrastructure.protocol.MongoProtocolRepository
-import br.all.infrastructure.protocol.toDocument
 import br.all.infrastructure.review.MongoSystematicStudyRepository
 import br.all.infrastructure.search.MongoSearchSessionRepository
 import br.all.infrastructure.shared.toNullable
@@ -50,18 +46,15 @@ class SearchSessionControllerTest(
 
 
     fun postUrl() = "/api/v1/systematic-study/$systematicStudyId/search-session"
-    fun patchUrl(sessionId: String = "") = "/api/v1/systematic-study/$systematicStudyId/patch-search-session${sessionId}"
-    fun findUrl(sessionId: String = "") =
-        "/api/v1/systematic-study/$systematicStudyId/search-session${sessionId}"
-
-    fun findBySourceUrl(source: String = "") =
+    fun patchUrl(sessionId: UUID) = "/api/v1/systematic-study/$systematicStudyId/patch-search-session/${sessionId}"
+    fun findUrl(sessionId: UUID) =
+        "/api/v1/systematic-study/$systematicStudyId/search-session/${sessionId}"
+    fun findAllUrl() = "/api/v1/systematic-study/$systematicStudyId/search-session"
+    fun findBySourceUrl(source: String) =
         "/api/v1/systematic-study/$systematicStudyId/search-session-source/${source}"
 
-    fun putUrl(
-        userId: UUID = factory.userId,
-        systematicStudyId: UUID = factory.systematicStudyId,
-        searchSessionId: UUID = factory.sessionId
-    ) = "/api/v1/systematic-study/$systematicStudyId/search-session/$searchSessionId"
+    fun putUrl(systematicStudyId: UUID = factory.systematicStudyId, searchSessionId: UUID = factory.sessionId) = "/api/v1/systematic-study/$systematicStudyId/search-session/$searchSessionId"
+
 
     @BeforeEach
     fun setUp() {
@@ -152,8 +145,7 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
-            mockMvc.perform(get(findUrl(sessionId))
+            mockMvc.perform(get(findUrl(searchSession.id))
                 .with(SecurityMockMvcRequestPostProcessors.user(user))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk)
@@ -167,10 +159,9 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
             testHelperService.testForUnauthorizedUser(
                 mockMvc,
-                get(findUrl(sessionId))
+                get(findUrl(searchSession.id))
                     .with(SecurityMockMvcRequestPostProcessors.user(unauthorizedUser))
             )
         }
@@ -181,29 +172,18 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
-            testHelperService.testForUnauthenticatedUser(mockMvc, get(findUrl(sessionId)),
+            testHelperService.testForUnauthenticatedUser(mockMvc, get(findUrl(searchSession.id)),
             )
         }
 
         @Test
         fun `should return 404 if don't find the search session`() {
             mockMvc.perform(
-                get(findUrl(factory.nonExistentSessionId.toString()))
+                get(findUrl(factory.nonExistentSessionId))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
             )
                 .andExpect(status().isNotFound)
-        }
-
-        @Test
-        fun `should return 400 if search session id is in a invalid format`() {
-            mockMvc.perform(
-                get(findUrl("/-1"))
-                    .with(SecurityMockMvcRequestPostProcessors.user(user))
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-                .andExpect(status().isBadRequest)
         }
 
         @Test
@@ -218,7 +198,7 @@ class SearchSessionControllerTest(
             repository.insert(factory.searchSessionDocument(id3, wrongSystematicStudyId))
 
             mockMvc.perform(
-                get(findUrl())
+                get(findAllUrl())
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
             )
@@ -228,16 +208,14 @@ class SearchSessionControllerTest(
         }
 
         @Test
-        fun `should return empty list and return 200 if no search session is found`() {
+        fun `should return 404 if no search session is found`() {
+            val id1 = UUID.randomUUID()
             mockMvc.perform(
-                get(findUrl())
+                get(findUrl(id1))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
             )
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$.systematicStudyId").value(systematicStudyId.toString()))
-                .andExpect(jsonPath("$.size").value(0))
-                .andExpect(jsonPath("$.searchSessions").isEmpty())
+                .andExpect(status().isNotFound)
         }
 
         @Test
@@ -354,19 +332,17 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
-            mockMvc.perform(multipart(patchUrl(sessionId))
-                .file(factory.bibfile())
-                .param("data", request)
-                .with(SecurityMockMvcRequestPostProcessors.user(user))
-                .with { req ->
-                    req.method = "PATCH"
-                    req
-                }
+            mockMvc.perform(
+                multipart(patchUrl(searchSession.id))
+                    .file(factory.bibfile())
+                    .param("data", request)
+                    .param("_method", "PATCH")
+                    .with(SecurityMockMvcRequestPostProcessors.user(user))
             )
                 .andExpect(status().isOk)
         }
     }
+
 
     @Nested
     @DisplayName("When deleting a search session")
@@ -377,9 +353,8 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
             mockMvc.perform(
-                delete(findUrl(sessionId))
+                delete(findUrl(searchSession.id))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
             )
@@ -389,9 +364,8 @@ class SearchSessionControllerTest(
         @Test
         fun `should return 404 when search session does not exist`() {
             val nonExistentSessionId = UUID.randomUUID()
-            val sessionId = "/$nonExistentSessionId"
             mockMvc.perform(
-                delete(findUrl(sessionId))
+                delete(findUrl(nonExistentSessionId))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
             )
@@ -403,10 +377,9 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
             testHelperService.testForUnauthorizedUser(
                 mockMvc,
-                delete(findUrl(sessionId))
+                delete(findUrl(searchSession.id))
                     .with(SecurityMockMvcRequestPostProcessors.user(unauthorizedUser))
             )
         }
@@ -416,10 +389,9 @@ class SearchSessionControllerTest(
             val searchSession = factory.searchSessionDocument(factory.sessionId, systematicStudyId)
             repository.insert(searchSession)
 
-            val sessionId = "/${searchSession.id}"
             testHelperService.testForUnauthenticatedUser(
                 mockMvc,
-                delete(findUrl(sessionId))
+                delete(findUrl(searchSession.id))
             )
         }
     }

--- a/web/src/test/kotlin/br/all/search/shared/TestDataFactory.kt
+++ b/web/src/test/kotlin/br/all/search/shared/TestDataFactory.kt
@@ -170,15 +170,11 @@ class TestDataFactory {
         return "{ ${jsonFields.joinToString(", ")} }"
     }
 
-    fun validPatchRequest(
-        user: UUID = userId,
-        systematicStudyId: UUID = this.systematicStudyId,
-        searchSessionId: UUID = this.sessionId
-    ) = """
+    fun validPatchRequest() = """
         {
-            "userId": "$user",
+            "userId": "$userId",
             "systematicStudyId": "$systematicStudyId",
-            "searchSessionId": "$searchSessionId"
+            "searchSessionId": "$sessionId"
         }
-        """.trimIndent()
+        """
 }

--- a/web/src/test/kotlin/br/all/search/shared/TestDataFactory.kt
+++ b/web/src/test/kotlin/br/all/search/shared/TestDataFactory.kt
@@ -48,29 +48,6 @@ class TestDataFactory {
         }
         """.trimIndent()
 
-    fun uniquenessViolationPostRequest(researcher: UUID = this.userId, systematicStudyId: UUID = this.systematicStudyId) =
-        """
-        {
-            "researcherId": "$researcher",
-            "systematicStudyId": "$systematicStudyId",
-            "source": "Source",
-            "searchString": "${faker.paragraph(5)}",
-            "additionalInfo": "${faker.paragraph(30)}"
-        }
-        """.trimIndent()
-
-    fun invalidPostRequest(
-        userId: UUID = UUID.randomUUID(),
-        systematicStudyId: UUID = UUID.randomUUID()
-    ) = """
-        {
-            "userId": "$userId",
-            "systematicStudyId": "$systematicStudyId",
-            "source": "",
-            "searchString": "",
-            "additionalInfo": ""
-        }
-        """.trimIndent()
 
     fun bibfile() = MockMultipartFile(
         "file",
@@ -159,14 +136,6 @@ class TestDataFactory {
             jsonFields.add("\"source\": \"$source\"")
         }
 
-        return "{ ${jsonFields.joinToString(", ")} }"
-    }
-
-    fun createUniquenessViolationPutRequest(
-        source: String
-    ): String {
-        val jsonFields = mutableListOf<String>()
-        jsonFields.add("\"source\": \"$source\"")
         return "{ ${jsonFields.joinToString(", ")} }"
     }
 

--- a/web/src/test/kotlin/br/all/study/controller/StudyReviewControllerTest.kt
+++ b/web/src/test/kotlin/br/all/study/controller/StudyReviewControllerTest.kt
@@ -34,7 +34,6 @@ class StudyReviewControllerTest(
     @Autowired private val testHelperService: TestHelperService,
     @Autowired val idService: StudyReviewIdGeneratorService,
     @Autowired val mockMvc: MockMvc,
-    @Autowired val objectMapper: ObjectMapper,
 ) {
 
     private lateinit var factory: TestDataFactory
@@ -62,7 +61,7 @@ class StudyReviewControllerTest(
     fun updateStatusStatus(attributeName: String, studyId: String) =
         "/api/v1/systematic-study/$systematicStudyId/study-review/${studyId}/${attributeName}"
 
-    fun markAsDuplicatedUrl(studyToUpdateId: UUID) =
+    fun markAsDuplicatedUrl(studyToUpdateId: Long) =
         "/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated"
 
     fun answerRiskOfBiasQuestion(studyReviewId: Long) =
@@ -583,7 +582,7 @@ class StudyReviewControllerTest(
             val duplicateIds = listOf(studyToDuplicateId)
 
             mockMvc.perform(
-                patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
+                patch(markAsDuplicatedUrl(studyToUpdateId))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(factory.validMarkAsDuplicateRequest(duplicateIds))
@@ -610,7 +609,7 @@ class StudyReviewControllerTest(
             val duplicateIds = listOf(studyToDuplicateId)
 
             mockMvc.perform(
-                patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
+                patch(markAsDuplicatedUrl(studyToUpdateId))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(factory.validMarkAsDuplicateRequest(duplicateIds))
@@ -629,7 +628,7 @@ class StudyReviewControllerTest(
             val duplicateIds = listOf(studyToDuplicateId)
 
             mockMvc.perform(
-                patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
+                patch(markAsDuplicatedUrl(studyToUpdateId))
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(factory.validMarkAsDuplicateRequest(duplicateIds))
@@ -646,7 +645,7 @@ class StudyReviewControllerTest(
 
             testHelperService.testForUnauthorizedUser(
                 mockMvc,
-                patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
+                patch(markAsDuplicatedUrl(studyToUpdateId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )
@@ -661,7 +660,7 @@ class StudyReviewControllerTest(
 
             testHelperService.testForUnauthenticatedUser(
                 mockMvc,
-                patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
+                patch(markAsDuplicatedUrl(studyToUpdateId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )

--- a/web/src/test/kotlin/br/all/study/controller/StudyReviewControllerTest.kt
+++ b/web/src/test/kotlin/br/all/study/controller/StudyReviewControllerTest.kt
@@ -586,7 +586,7 @@ class StudyReviewControllerTest(
                 patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(duplicateIds))
+                    .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )
                 .andDo(print())
                 .andExpect(status().isOk)
@@ -613,7 +613,7 @@ class StudyReviewControllerTest(
                 patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(duplicateIds))
+                    .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )
                 .andExpect(status().isNotFound)
         }
@@ -632,7 +632,7 @@ class StudyReviewControllerTest(
                 patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(duplicateIds))
+                    .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )
                 .andExpect(status().isNotFound)
         }
@@ -648,7 +648,7 @@ class StudyReviewControllerTest(
                 mockMvc,
                 patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(duplicateIds))
+                    .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )
         }
 
@@ -663,7 +663,7 @@ class StudyReviewControllerTest(
                 mockMvc,
                 patch("/api/v1/systematic-study/$systematicStudyId/study-review/$studyToUpdateId/duplicated")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(duplicateIds))
+                    .content(factory.validMarkAsDuplicateRequest(duplicateIds))
             )
         }
     }

--- a/web/src/test/kotlin/br/all/study/controller/StudyReviewControllerTest.kt
+++ b/web/src/test/kotlin/br/all/study/controller/StudyReviewControllerTest.kt
@@ -9,7 +9,6 @@ import br.all.infrastructure.study.StudyReviewIdGeneratorService
 import br.all.security.service.ApplicationUser
 import br.all.shared.TestHelperService
 import br.all.study.utils.TestDataFactory
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/web/src/test/kotlin/br/all/study/utils/TestDataFactory.kt
+++ b/web/src/test/kotlin/br/all/study/utils/TestDataFactory.kt
@@ -108,6 +108,13 @@ class TestDataFactory {
         }
         """
 
+    fun validMarkAsDuplicateRequest(duplicateStudyIds: List<Long>) =
+        """
+            {
+                "duplicatedStudyIds": $duplicateStudyIds
+            }
+        """
+
 
     fun reviewDocument(
         systematicStudyId: UUID,


### PR DESCRIPTION
Duplicate studies endpoint did not have a data class for the request model. This PR adress this problem, by adding a data class and fixing depending files.