### PR TITLE
feat(score): calculate Study Review score based on protocol keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/discord.xml
 *.iws
 *.iml
 *.ipr

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Then, you may download or clone the application and open the project there. It w
 
 Following that, you will need to run the [Docker Engine](https://www.docker.com/products/docker-desktop/). It has to be running on your computer for the program to function.
 Then, you must open a terminal on the folder the project is on (or click on the terminal button in your IDE), and run the following command to initialize the container:
-
-`docker compose up -d --build`
-
+```bash
+docker compose up -d --build
+```
 The above command must be used every time you want to use the project.
 
 Now, all that's left is to open the `web` module > `src` > `main` > `kotlin` > `br.all` > right-click on `WebApplication.kt` and click on **Run 'WebApplication.main()'**

--- a/README.md
+++ b/README.md
@@ -14,9 +14,22 @@ Then, you must open a terminal on the folder the project is on (or click on the 
 
 The above command must be used every time you want to use the project.
 
-Now, all that's left is to open the `web` module > `src` > `main` > `kotlin` > `br.all` > right-click on `WebApplication.kt` and click on **Run 'WebApplication.main()'** 
+Now, all that's left is to open the `web` module > `src` > `main` > `kotlin` > `br.all` > right-click on `WebApplication.kt` and click on **Run 'WebApplication.main()'**
 
 There! Now the back-end is up and running and can process HTTP requests.
+
+### Troubleshooting
+If you're using Windows and encounter a password authentication failed error when attempting to run WebApplication, it’s likely due to Docker not connecting properly to the PostgreSQL container.
+
+By default, the database URL in `application.yaml` is set to:
+```yaml
+url: jdbc:postgresql://localhost:5432/start
+```
+On Windows, you may need to replace it with:
+```yaml
+url: jdbc:postgresql://host.docker.internal:5432/start
+```
+This change ensures the application connects correctly to the PostgreSQL service inside the Docker container using Docker's internal networking.
 
 ## Requests
 The project is currently set to run on the address `http://localhost:8080`. To view all possible requests, as documented on the application, open the following page on your browser:

--- a/review/src/main/kotlin/br/all/application/search/create/CreateSearchSessionServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/search/create/CreateSearchSessionServiceImpl.kt
@@ -19,6 +19,7 @@ import br.all.domain.model.review.toSystematicStudyId
 import br.all.domain.model.search.SearchSession
 import br.all.domain.model.search.SearchSessionID
 import br.all.domain.services.ConverterFactoryService
+import br.all.domain.services.ScoreCalculatorService
 import br.all.domain.services.UuidGeneratorService
 
 class CreateSearchSessionServiceImpl(
@@ -55,6 +56,7 @@ class CreateSearchSessionServiceImpl(
             return
         }
 
+        val scoreCalculatorService = ScoreCalculatorService(protocolDto)
         val sessionId = SearchSessionID(uuidGeneratorService.next())
         val searchSession = SearchSession.fromRequestModel(sessionId, request)
 
@@ -65,7 +67,8 @@ class CreateSearchSessionServiceImpl(
             mutableSetOf(source)
         )
 
-        studyReviewRepository.saveOrUpdateBatch(studyReviews.map { it.toDto() })
+        val scoredStudyReviews = scoreCalculatorService.applyScoreToManyStudyReviews(studyReviews)
+        studyReviewRepository.saveOrUpdateBatch(scoredStudyReviews.map { it.toDto() })
 
         val numberOfRelatedStudies = studyReviews.size
         searchSession.numberOfRelatedStudies = numberOfRelatedStudies

--- a/review/src/main/kotlin/br/all/application/search/create/CreateSearchSessionServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/search/create/CreateSearchSessionServiceImpl.kt
@@ -56,7 +56,7 @@ class CreateSearchSessionServiceImpl(
             return
         }
 
-        val scoreCalculatorService = ScoreCalculatorService(protocolDto)
+        val scoreCalculatorService = ScoreCalculatorService(protocolDto?.keywords)
         val sessionId = SearchSessionID(uuidGeneratorService.next())
         val searchSession = SearchSession.fromRequestModel(sessionId, request)
 

--- a/review/src/main/kotlin/br/all/application/study/repository/StudyReviewDto.kt
+++ b/review/src/main/kotlin/br/all/application/study/repository/StudyReviewDto.kt
@@ -23,5 +23,6 @@ data class StudyReviewDto(
     val readingPriority: String,
     val extractionStatus: String,
     val selectionStatus: String,
+    val score: Int
 )
 

--- a/review/src/main/kotlin/br/all/application/study/repository/StudyReviewMapper.kt
+++ b/review/src/main/kotlin/br/all/application/study/repository/StudyReviewMapper.kt
@@ -28,7 +28,8 @@ fun StudyReview.toDto() = StudyReviewDto(
     comments,
     readingPriority.toString(),
     extractionStatus.toString(),
-    selectionStatus.toString()
+    selectionStatus.toString(),
+    score
 )
 
 
@@ -52,7 +53,8 @@ fun StudyReview.Companion.fromDto(dto: StudyReviewDto) = StudyReview(
     dto.comments,
     ReadingPriority.valueOf(dto.readingPriority),
     SelectionStatus.valueOf(dto.selectionStatus),
-    ExtractionStatus.valueOf(dto.extractionStatus)
+    ExtractionStatus.valueOf(dto.extractionStatus),
+    dto.score
 )
 
 

--- a/review/src/main/kotlin/br/all/application/study/repository/StudyReviewMapper.kt
+++ b/review/src/main/kotlin/br/all/application/study/repository/StudyReviewMapper.kt
@@ -3,7 +3,6 @@ package br.all.application.study.repository
 import br.all.application.study.create.CreateStudyReviewService.RequestModel
 import br.all.application.study.update.interfaces.UpdateStudyReviewService
 import br.all.domain.model.protocol.Criterion
-import br.all.domain.model.protocol.Criterion.CriterionType
 import br.all.domain.model.review.SystematicStudyId
 import br.all.domain.model.search.SearchSessionID
 import br.all.domain.model.study.*

--- a/review/src/main/kotlin/br/all/domain/model/study/StudyReview.kt
+++ b/review/src/main/kotlin/br/all/domain/model/study/StudyReview.kt
@@ -26,6 +26,7 @@ class StudyReview(
     var readingPriority: ReadingPriority = ReadingPriority.LOW,
     selectionStatus: SelectionStatus = SelectionStatus.UNCLASSIFIED,
     extractionStatus: ExtractionStatus = ExtractionStatus.UNCLASSIFIED,
+    var score: Int = 0
 ) : Entity<Long>(studyId) {
 
     private val study: Study
@@ -52,9 +53,6 @@ class StudyReview(
         private set
     var extractionStatus: ExtractionStatus = extractionStatus
         private set
-
-    var score: Int = 0
-        internal set
 
     init {
         require(searchSources.size > 0) { "The study must be related to at least one search source." }

--- a/review/src/main/kotlin/br/all/domain/model/study/StudyReview.kt
+++ b/review/src/main/kotlin/br/all/domain/model/study/StudyReview.kt
@@ -53,6 +53,9 @@ class StudyReview(
     var extractionStatus: ExtractionStatus = extractionStatus
         private set
 
+    var score: Int = 0
+        internal set
+
     init {
         require(searchSources.size > 0) { "The study must be related to at least one search source." }
         study = Study(studyType, title, year, authors, venue, abstract, keywords, references, doi)

--- a/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
+++ b/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
@@ -1,0 +1,23 @@
+package br.all.domain.services
+
+import br.all.domain.model.protocol.Protocol
+import br.all.domain.model.study.StudyReview
+
+class ScoreCalculatorService(
+    val protocol: Protocol
+) {
+    private fun calculateScore(studyReview: StudyReview): Int {
+        val keywords = protocol.keywords
+        var score = 0
+
+        for (keyword in keywords) {
+            val regex = Regex("\\b$keyword\\b", RegexOption.IGNORE_CASE)
+
+            if (regex.containsMatchIn(studyReview.title)) score += 5
+            if (studyReview.abstract?.let { regex.containsMatchIn(it) } == true) score += 3
+            if (studyReview.keywords.any { regex.containsMatchIn(it) }) score += 2
+        }
+
+        return score
+    }
+}

--- a/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
+++ b/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
@@ -1,21 +1,21 @@
 package br.all.domain.services
 
-import br.all.application.protocol.repository.ProtocolDto
 import br.all.domain.model.study.StudyReview
 
 class ScoreCalculatorService(
-    val protocol: ProtocolDto?
+    private val protocolKeywords: Set<String>?
 ) {
     private fun calculateScore(title: String, abstract: String?, authorsKeywords: Set<String>): Int {
-        val keywords = protocol?.keywords ?: emptySet()
         var score = 0
 
-        for (keyword in keywords) {
-            val regex = Regex("\\b$keyword\\b", RegexOption.IGNORE_CASE)
+        if (protocolKeywords != null) {
+            for (keyword in protocolKeywords) {
+                val regex = Regex("\\b$keyword\\b", RegexOption.IGNORE_CASE)
 
-            if (regex.containsMatchIn(title)) score += 5
-            if (abstract?.let { regex.containsMatchIn(it) } == true) score += 3
-            if (authorsKeywords.any { regex.containsMatchIn(it) }) score += 2
+                if (regex.containsMatchIn(title)) score += 5
+                if (abstract?.let { regex.containsMatchIn(it) } == true) score += 3
+                if (authorsKeywords.any { regex.containsMatchIn(it) }) score += 2
+            }
         }
 
         return score

--- a/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
+++ b/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
@@ -1,13 +1,13 @@
 package br.all.domain.services
 
-import br.all.domain.model.protocol.Protocol
+import br.all.application.protocol.repository.ProtocolDto
 import br.all.domain.model.study.StudyReview
 
 class ScoreCalculatorService(
-    val protocol: Protocol
+    val protocol: ProtocolDto?
 ) {
     private fun calculateScore(title: String, abstract: String?, authorsKeywords: Set<String>): Int {
-        val keywords = protocol.keywords
+        val keywords = protocol?.keywords ?: emptySet()
         var score = 0
 
         for (keyword in keywords) {

--- a/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
+++ b/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
@@ -21,8 +21,12 @@ class ScoreCalculatorService(
         return score
     }
 
-    fun applyScoreToStudyReview(studyReview: StudyReview): StudyReview {
+    private fun applyScoreToStudyReview(studyReview: StudyReview): StudyReview {
         val score = calculateScore(studyReview.title, studyReview.abstract, studyReview.keywords)
         return studyReview.apply { this.score = score }
+    }
+
+    fun applyScoreToManyStudyReviews(studyReviews: List<StudyReview>): List<StudyReview> {
+        return studyReviews.map { applyScoreToStudyReview(it) }
     }
 }

--- a/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
+++ b/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
@@ -20,4 +20,9 @@ class ScoreCalculatorService(
 
         return score
     }
+
+    fun applyScoreToStudyReview(studyReview: StudyReview): StudyReview {
+        val score = calculateScore(studyReview.title, studyReview.abstract, studyReview.keywords)
+        return studyReview.apply { this.score = score }
+    }
 }

--- a/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
+++ b/review/src/main/kotlin/br/all/domain/services/ScoreCalculatorService.kt
@@ -6,16 +6,16 @@ import br.all.domain.model.study.StudyReview
 class ScoreCalculatorService(
     val protocol: Protocol
 ) {
-    private fun calculateScore(studyReview: StudyReview): Int {
+    private fun calculateScore(title: String, abstract: String?, authorsKeywords: Set<String>): Int {
         val keywords = protocol.keywords
         var score = 0
 
         for (keyword in keywords) {
             val regex = Regex("\\b$keyword\\b", RegexOption.IGNORE_CASE)
 
-            if (regex.containsMatchIn(studyReview.title)) score += 5
-            if (studyReview.abstract?.let { regex.containsMatchIn(it) } == true) score += 3
-            if (studyReview.keywords.any { regex.containsMatchIn(it) }) score += 2
+            if (regex.containsMatchIn(title)) score += 5
+            if (abstract?.let { regex.containsMatchIn(it) } == true) score += 3
+            if (authorsKeywords.any { regex.containsMatchIn(it) }) score += 2
         }
 
         return score

--- a/review/src/main/kotlin/br/all/infrastructure/study/StudyReviewDbMapper.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/study/StudyReviewDbMapper.kt
@@ -22,7 +22,8 @@ fun StudyReviewDocument.toDto() = StudyReviewDto(
     comments,
     readingPriority,
     extractionStatus,
-    selectionStatus
+    selectionStatus,
+    score
 )
 
 fun StudyReviewDto.toDocument() = StudyReviewDocument(
@@ -44,5 +45,6 @@ fun StudyReviewDto.toDocument() = StudyReviewDocument(
     comments,
     readingPriority,
     extractionStatus,
-    selectionStatus
+    selectionStatus,
+    score
 )

--- a/review/src/main/kotlin/br/all/infrastructure/study/StudyReviewDocument.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/study/StudyReviewDocument.kt
@@ -25,7 +25,8 @@ data class StudyReviewDocument (
     val comments: String,
     val readingPriority: String,
     val extractionStatus: String,
-    val selectionStatus: String
+    val selectionStatus: String,
+    val score: Int
 ){
     companion object{
         @Transient

--- a/review/src/test/kotlin/br/all/application/study/util/TestDataFactory.kt
+++ b/review/src/test/kotlin/br/all/application/study/util/TestDataFactory.kt
@@ -48,13 +48,14 @@ class TestDataFactory {
         comments: String = faker.paragraph(15),
         selectionStatus: String = "UNCLASSIFIED",
         extractionStatus: String = "UNCLASSIFIED",
-        readingPriority: String = "LOW"
+        readingPriority: String = "LOW",
+        score: Int = 0
     ): StudyReviewDto {
         return StudyReviewDto(
             studyReviewId, systematicStudyId, searchSessionId, type, title, year,
             authors, venue, abstract, keywords, references, doi, sources,
             criteria, formAnswers, robAnswers, comments, readingPriority,
-            extractionStatus, selectionStatus
+            extractionStatus, selectionStatus, score
         )
     }
 

--- a/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceData.kt
+++ b/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceData.kt
@@ -1,0 +1,101 @@
+package br.all.domain.services
+
+import br.all.domain.model.protocol.Criterion
+import br.all.domain.model.review.SystematicStudyId
+import br.all.domain.model.search.SearchSessionID
+import br.all.domain.model.study.*
+import java.util.*
+
+object ScoreCalculatorServiceData {
+    val baseStudyReview = StudyReview(
+        studyId = StudyReviewId(1L),
+        systematicStudyId = SystematicStudyId(UUID.randomUUID()),
+        searchSessionId = SearchSessionID(UUID.randomUUID()),
+        studyType = StudyType.ARTICLE,
+        title = "Crescimento da dengue em países tropicais",
+        year = 2025,
+        authors = "Fulano de Tal",
+        venue = "Universidade X",
+        abstract = "O clima atual favorece a reprodução do mosquito Aedes aegypti, aumentando o crescimento da dengue em países tropicais.",
+        doi = Doi("https://doi.org/10.1234/dengue.2025.001"),
+        keywords = setOf("dengue", "mosquito", "países tropicais"),
+        searchSources = mutableSetOf("PubMed", "SciELO"),
+        references = emptyList(),
+        criteria = mutableSetOf(Criterion("test", Criterion.CriterionType.INCLUSION)),
+        formAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        robAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        comments = "Comentário de revisão 1",
+        readingPriority = ReadingPriority.LOW,
+        selectionStatus = SelectionStatus.INCLUDED,
+        extractionStatus = ExtractionStatus.INCLUDED
+    )
+
+    val noMatchStudyReview = StudyReview(
+        studyId = StudyReviewId(1L),
+        systematicStudyId = SystematicStudyId(UUID.randomUUID()),
+        searchSessionId = SearchSessionID(UUID.randomUUID()),
+        studyType = StudyType.ARTICLE,
+        title = "Tecnologias de computação quântica na medicina moderna",
+        year = 2025,
+        authors = "Fulano de Tal",
+        venue = "Universidade X",
+        abstract = "Estudo de algoritmos de machine learning aplicados à genômica usando computação quântica",
+        doi = Doi("https://doi.org/10.1234/dengue.2025.001"),
+        keywords = setOf("computação quântica", "machine learning", "genômica"),
+        searchSources = mutableSetOf("a", "b"),
+        references = emptyList(),
+        criteria = mutableSetOf(Criterion("test", Criterion.CriterionType.INCLUSION)),
+        formAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        robAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        comments = "Comentário de revisão 1",
+        readingPriority = ReadingPriority.LOW,
+        selectionStatus = SelectionStatus.INCLUDED,
+        extractionStatus = ExtractionStatus.INCLUDED
+    )
+
+    val partialMatchStudyReview = StudyReview(
+        studyId = StudyReviewId(1L),
+        systematicStudyId = SystematicStudyId(UUID.randomUUID()),
+        searchSessionId = SearchSessionID(UUID.randomUUID()),
+        studyType = StudyType.ARTICLE,
+        title = "Dengue em regiões urbanas",
+        year = 2025,
+        authors = "Fulano de Tal",
+        venue = "Universidade X",
+        abstract = "Análise de fatores sociais e ambientais que afetam a propagação da dengue.",
+        doi = Doi("https://doi.org/10.1234/dengue.2025.001"),
+        keywords = setOf("dengue", "regiões urbanas", "clima"),
+        searchSources = mutableSetOf("a", "b"),
+        references = emptyList(),
+        criteria = mutableSetOf(Criterion("test", Criterion.CriterionType.INCLUSION)),
+        formAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        robAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        comments = "Comentário de revisão 1",
+        readingPriority = ReadingPriority.LOW,
+        selectionStatus = SelectionStatus.INCLUDED,
+        extractionStatus = ExtractionStatus.INCLUDED
+    )
+
+    val nullAbstractStudyReview = StudyReview(
+        studyId = StudyReviewId(1L),
+        systematicStudyId = SystematicStudyId(UUID.randomUUID()),
+        searchSessionId = SearchSessionID(UUID.randomUUID()),
+        studyType = StudyType.ARTICLE,
+        title = "Crescimento da dengue em países tropicais",
+        year = 2025,
+        authors = "Fulano de Tal",
+        venue = "Universidade X",
+        abstract = null,
+        doi = Doi("https://doi.org/10.1234/dengue.2025.001"),
+        keywords = setOf("dengue", "mosquito", "países tropicais"),
+        searchSources = mutableSetOf("PubMed", "SciELO"),
+        references = emptyList(),
+        criteria = mutableSetOf(Criterion("test", Criterion.CriterionType.INCLUSION)),
+        formAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        robAnswers = mutableSetOf(Answer(UUID.randomUUID(), String)),
+        comments = "Comentário de revisão 1",
+        readingPriority = ReadingPriority.LOW,
+        selectionStatus = SelectionStatus.INCLUDED,
+        extractionStatus = ExtractionStatus.INCLUDED
+    )
+}

--- a/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTest.kt
+++ b/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTest.kt
@@ -1,9 +1,9 @@
 package br.all.domain.services
 
-import br.all.domain.services.ScoreCalculatorServiceData.baseStudyReview
-import br.all.domain.services.ScoreCalculatorServiceData.noMatchStudyReview
-import br.all.domain.services.ScoreCalculatorServiceData.nullAbstractStudyReview
-import br.all.domain.services.ScoreCalculatorServiceData.partialMatchStudyReview
+import br.all.domain.services.ScoreCalculatorServiceTestData.baseStudyReview
+import br.all.domain.services.ScoreCalculatorServiceTestData.noMatchStudyReview
+import br.all.domain.services.ScoreCalculatorServiceTestData.nullAbstractStudyReview
+import br.all.domain.services.ScoreCalculatorServiceTestData.partialMatchStudyReview
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals

--- a/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTest.kt
+++ b/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTest.kt
@@ -22,9 +22,6 @@ class ScoreCalculatorServiceTest {
     fun `should assign maximum score when all keywords match in all fields`() {
         val result = sut.applyScoreToManyStudyReviews(listOf(baseStudyReview)).first()
 
-        // - "dengue" title (5), abstract (3), keywords (2) = 10
-        // - "mosquito" abstract (3), keywords (2) = 5
-        // - "países tropicais" title (5), abstract (3), keywords (2) = 10
         assertEquals(25, result.score)
     }
 
@@ -37,18 +34,12 @@ class ScoreCalculatorServiceTest {
     @Test
     fun `should assign partial score when only some keywords match`() {
         val result = sut.applyScoreToManyStudyReviews(listOf(partialMatchStudyReview)).first()
-
-        // "dengue" title (5), abstract (3), keywords (2) = 10
         assertEquals(10, result.score)
     }
 
     @Test
     fun `should handle study review with null abstract`() {
         val result = sut.applyScoreToManyStudyReviews(listOf(nullAbstractStudyReview)).first()
-
-        // "dengue" title (5) + keywords (2) = 7
-        // "mosquito" keywords (2) = 2
-        // "países tropicais" title (5), keywords (2) = 7
         assertEquals(16, result.score)
     }
 
@@ -56,7 +47,6 @@ class ScoreCalculatorServiceTest {
     fun `should return list with correct size and scores`() {
         val input = listOf(baseStudyReview, noMatchStudyReview, partialMatchStudyReview)
         val results = sut.applyScoreToManyStudyReviews(input)
-
         assertEquals(3, results.size)
         assertEquals(25, results[0].score)
         assertEquals(0, results[1].score)

--- a/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTest.kt
+++ b/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTest.kt
@@ -1,0 +1,65 @@
+package br.all.domain.services
+
+import br.all.domain.services.ScoreCalculatorServiceData.baseStudyReview
+import br.all.domain.services.ScoreCalculatorServiceData.noMatchStudyReview
+import br.all.domain.services.ScoreCalculatorServiceData.nullAbstractStudyReview
+import br.all.domain.services.ScoreCalculatorServiceData.partialMatchStudyReview
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ScoreCalculatorServiceTest {
+
+    private lateinit var sut: ScoreCalculatorService
+
+    @BeforeEach
+    fun setup() {
+        val protocolKeywords = setOf("dengue", "mosquito", "países tropicais")
+        sut = ScoreCalculatorService(protocolKeywords)
+    }
+
+    @Test
+    fun `should assign maximum score when all keywords match in all fields`() {
+        val result = sut.applyScoreToManyStudyReviews(listOf(baseStudyReview)).first()
+
+        // - "dengue" title (5), abstract (3), keywords (2) = 10
+        // - "mosquito" abstract (3), keywords (2) = 5
+        // - "países tropicais" title (5), abstract (3), keywords (2) = 10
+        assertEquals(25, result.score)
+    }
+
+    @Test
+    fun `should assign zero score when none of the keywords match`() {
+        val result = sut.applyScoreToManyStudyReviews(listOf(noMatchStudyReview)).first()
+        assertEquals(0, result.score)
+    }
+
+    @Test
+    fun `should assign partial score when only some keywords match`() {
+        val result = sut.applyScoreToManyStudyReviews(listOf(partialMatchStudyReview)).first()
+
+        // "dengue" title (5), abstract (3), keywords (2) = 10
+        assertEquals(10, result.score)
+    }
+
+    @Test
+    fun `should handle study review with null abstract`() {
+        val result = sut.applyScoreToManyStudyReviews(listOf(nullAbstractStudyReview)).first()
+
+        // "dengue" title (5) + keywords (2) = 7
+        // "mosquito" keywords (2) = 2
+        // "países tropicais" title (5), keywords (2) = 7
+        assertEquals(16, result.score)
+    }
+
+    @Test
+    fun `should return list with correct size and scores`() {
+        val input = listOf(baseStudyReview, noMatchStudyReview, partialMatchStudyReview)
+        val results = sut.applyScoreToManyStudyReviews(input)
+
+        assertEquals(3, results.size)
+        assertEquals(25, results[0].score)
+        assertEquals(0, results[1].score)
+        assertEquals(10, results[2].score)
+    }
+}

--- a/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTestData.kt
+++ b/review/src/test/kotlin/br/all/domain/services/ScoreCalculatorServiceTestData.kt
@@ -6,7 +6,7 @@ import br.all.domain.model.search.SearchSessionID
 import br.all.domain.model.study.*
 import java.util.*
 
-object ScoreCalculatorServiceData {
+object ScoreCalculatorServiceTestData {
     val baseStudyReview = StudyReview(
         studyId = StudyReviewId(1L),
         systematicStudyId = SystematicStudyId(UUID.randomUUID()),

--- a/web/src/main/kotlin/br/all/study/presenter/RestfulFindStudyReviewPresenter.kt
+++ b/web/src/main/kotlin/br/all/study/presenter/RestfulFindStudyReviewPresenter.kt
@@ -4,11 +4,8 @@ import br.all.application.study.find.presenter.FindStudyReviewPresenter
 import br.all.application.study.find.service.FindStudyReviewService.ResponseModel
 import br.all.application.study.repository.StudyReviewDto
 import br.all.shared.error.createErrorResponseFrom
-import br.all.study.controller.StudyReviewController
-import br.all.study.requests.PostStudyReviewRequest
 import br.all.utils.LinksFactory
 import org.springframework.hateoas.RepresentationModel
-import org.springframework.hateoas.server.mvc.linkTo
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component

--- a/web/src/main/kotlin/br/all/study/presenter/RestfulFindStudyReviewPresenter.kt
+++ b/web/src/main/kotlin/br/all/study/presenter/RestfulFindStudyReviewPresenter.kt
@@ -54,5 +54,6 @@ class RestfulFindStudyReviewPresenter(
         val readingPriority = content.readingPriority
         val extractionStatus = content.extractionStatus
         val selectionStatus = content.selectionStatus
+        val score = content.score
     }
 }


### PR DESCRIPTION
## Summary

Introducing a scoring mechanism for Study Reviews based on the presence of protocol keywords. The score reflects how closely a Study Review aligns with the protocol, using keyword matches in the title, abstract, and author's keywords.

## Changes

1. **Updated `README.md`**  
   - Added clarification for a PostgreSQL connection issue on Windows when using Docker.
   
2. **Implemented `ScoreCalculatorService`**  
   - Calculates score based on keyword occurrences:
     - **Title match**: +5 points  
     - **Abstract match**: +3 points  
     - **Author's keyword match**: +2 points  

3. **Integrated scoring into `CreateSearchSessionServiceImpl`**  
   - Applies the score to each Study Review after session creation.

4. **Added unit tests**  
   - Tests cover the new scoring logic in `ScoreCalculatorService`.

5. **Updated DTOs and Document classes**  
   - Ensures the `score` field is visible in Study Review API responses.