### PR TITLE
Feat/review export

### DIFF
--- a/review/src/main/kotlin/br/all/application/report/export/FunnelExportData.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/FunnelExportData.kt
@@ -1,0 +1,15 @@
+package br.all.application.report.export
+
+data class FunnelExportData(
+    val totalIdentifiedBySource: Map<String, Int>,
+    val totalAfterDuplicatesRemovedBySource: Map<String, Int>,
+    val totalScreened: Int,
+    val totalExcludedInScreening: Int,
+    val excludedByCriterion: Map<String, Int>,
+    val totalFullTextAssessed: Int,
+    val totalExcludedInFullText: Int,
+    val totalExcludedByCriterion: Map<String, Int>,
+    val totalIncluded: Int
+)
+
+

--- a/review/src/main/kotlin/br/all/application/report/export/ProtocolExportData.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/ProtocolExportData.kt
@@ -1,0 +1,56 @@
+package br.all.application.report.export
+
+data class ProtocolExportData(
+    val id: String,
+    val systematicStudy: String,
+
+    val goal: String,
+    val justification: String,
+
+    val researchQuestions: List<String>,
+    val keywords: List<String>,
+    val searchString: String,
+    val informationSources: List<String>,
+    val sourcesSelectionCriteria: String,
+
+    val searchMethod: String,
+    val studiesLanguages: List<String>,
+    val studyTypeDefinition: String,
+
+    val selectionProcess: String,
+    val eligibilityCriteria: List<CriterionExportData>,
+
+    val dataCollectionProcess: String,
+    val analysisAndSynthesisProcess: String,
+
+    val extractionQuestions: List<String>,
+    val robQuestions: List<String>,
+
+    val picoc: PicocExportData?,
+){
+    fun inclusionCriteria(): List<String> {
+        return eligibilityCriteria
+            .filter { it.type == "INCLUSION" }
+            .map { it.description }
+    }
+
+    fun exclusionCriteria(): List<String> {
+        return eligibilityCriteria
+            .filter { it.type == "EXCLUSION" }
+            .map { it.description }
+    }
+
+}
+
+data class CriterionExportData(
+    val description: String,
+    val type: String
+)
+
+data class PicocExportData(
+    val population: String? = null,
+    val intervention: String? = null,
+    val control: String? = null,
+    val outcome: String? = null,
+    val context: String? = null
+)

--- a/review/src/main/kotlin/br/all/application/report/export/ReviewExportData.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/ReviewExportData.kt
@@ -1,0 +1,11 @@
+package br.all.application.report.export
+
+data class  ReviewExportData(
+    val systematicStudy: SystematicReviewExportData,
+    val protocol: ProtocolExportData,
+    val studiesIncludedInScreening: List<StudyExportData>,
+    val studiesExcludedInScreening: List<StudyExportData>,
+    val includedStudies: List<StudyExportData>,
+    val studiesExcludedInFullText: List<StudyExportData>,
+    val funnel: FunnelExportData
+)

--- a/review/src/main/kotlin/br/all/application/report/export/ReviewExporter.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/ReviewExporter.kt
@@ -1,0 +1,7 @@
+package br.all.application.report.export
+
+interface ReviewExporter {
+    val format: String
+    fun export(data: ReviewExportData): String
+
+}

--- a/review/src/main/kotlin/br/all/application/report/export/StudyExportData.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/StudyExportData.kt
@@ -1,0 +1,20 @@
+package br.all.application.report.export
+
+data class StudyExportData(
+    val id: Long,
+    val title: String,
+    val authors: String,
+    val year: Int,
+    val venue: String,
+    val doi: String?,
+    val keywords: Set<String>,
+    val selectionCriteria: Set<String>,
+    val extractionAnswers: List<QuestionAnswerExportData>,
+    val robAnswers: List<QuestionAnswerExportData>
+)
+
+data class QuestionAnswerExportData(
+    val question: String,
+    val answer: String?
+)
+

--- a/review/src/main/kotlin/br/all/application/report/export/SystematicReviewExportData.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/SystematicReviewExportData.kt
@@ -1,0 +1,13 @@
+package br.all.application.report.export
+
+import java.util.UUID
+
+data class SystematicReviewExportData(
+    val id: UUID,
+    val title: String,
+    val description: String,
+    val owner: String,
+    val collaborators: Set<String>,
+    val objectives: String
+)
+

--- a/review/src/main/kotlin/br/all/application/report/export/presenter/ExportReviewPresenter.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/presenter/ExportReviewPresenter.kt
@@ -1,0 +1,6 @@
+package br.all.application.report.export.presenter
+
+import br.all.application.report.export.service.ExportReviewService
+import br.all.domain.shared.presenter.GenericPresenter
+
+interface ExportReviewPresenter : GenericPresenter<ExportReviewService.ResponseModel>

--- a/review/src/main/kotlin/br/all/application/report/export/service/ExportReviewService.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/service/ExportReviewService.kt
@@ -1,0 +1,21 @@
+package br.all.application.report.export.service
+
+import br.all.application.report.export.presenter.ExportReviewPresenter
+import java.util.UUID
+
+interface ExportReviewService {
+    fun exportReview(presenter: ExportReviewPresenter, request: RequestModel)
+
+    data class RequestModel(
+        val userId: UUID,
+        val systematicStudyId: UUID,
+        val format: String,
+    )
+
+    data class ResponseModel(
+        val userId: UUID,
+        val systematicStudyId: UUID,
+        val format: String,
+        val formattedReview: String
+    )
+}

--- a/review/src/main/kotlin/br/all/application/report/export/service/ExportReviewServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/report/export/service/ExportReviewServiceImpl.kt
@@ -1,0 +1,154 @@
+package br.all.application.report.export.service
+import br.all.application.protocol.repository.PicocDto
+import br.all.application.protocol.repository.ProtocolDto
+import br.all.application.protocol.repository.ProtocolRepository
+import br.all.application.question.repository.QuestionDto
+import br.all.application.question.repository.QuestionRepository
+import br.all.application.report.export.*
+import br.all.application.report.export.presenter.ExportReviewPresenter
+import br.all.application.review.repository.SystematicStudyDto
+import br.all.application.review.repository.SystematicStudyRepository
+import br.all.application.review.repository.fromDto
+import br.all.application.shared.presenter.FunnelCalculator
+import br.all.application.shared.presenter.prepareIfFailsPreconditions
+import br.all.application.study.repository.StudyReviewDto
+import br.all.application.study.repository.StudyReviewRepository
+import br.all.application.user.CredentialsService
+import br.all.domain.model.question.QuestionContextEnum
+import br.all.domain.model.review.SystematicStudy
+import br.all.domain.model.study.ExtractionStatus
+import br.all.domain.model.study.SelectionStatus
+import br.all.domain.shared.exception.EntityNotFoundException
+
+class ExportReviewServiceImpl(
+    private val credentialsService: CredentialsService,
+    private val systematicStudyRepository: SystematicStudyRepository,
+    private val protocolRepository: ProtocolRepository,
+    private val studyReviewRepository: StudyReviewRepository,
+    private val questionRepository: QuestionRepository,
+    private val exporters: Map<String, ReviewExporter>
+) : ExportReviewService {
+
+    override fun exportReview(presenter: ExportReviewPresenter, request: ExportReviewService.RequestModel) {
+        val user = credentialsService.loadCredentials(request.userId)?.toUser()
+        val systematicStudyDto = systematicStudyRepository.findById(request.systematicStudyId)
+        val systematicStudy = systematicStudyDto?.let { SystematicStudy.fromDto(it) }
+
+        presenter.prepareIfFailsPreconditions(user, systematicStudy)
+        if (presenter.isDone()) return
+
+        val exporter = exporters[request.format]
+        if (exporter == null) {
+            presenter.prepareFailView(EntityNotFoundException("Invalid export format ${request.format}"))
+            return
+        }
+
+        val protocolDto = protocolRepository.findById(request.systematicStudyId)!!
+        val allStudies = studyReviewRepository.findAllFromReview(request.systematicStudyId)
+        val extractionQuestions = questionRepository.findAllBySystematicStudyId(
+            request.systematicStudyId, QuestionContextEnum.EXTRACTION
+        )
+        val robQuestions = questionRepository.findAllBySystematicStudyId(
+            request.systematicStudyId, QuestionContextEnum.ROB
+        )
+
+
+        val excludedInScreening = allStudies.filter {
+            it.selectionStatus == SelectionStatus.EXCLUDED.name
+        }
+
+        val includedInScreening = allStudies.filter {
+            it.selectionStatus == SelectionStatus.INCLUDED.name
+        }
+
+        val excludedInFullText = allStudies.filter {
+            it.selectionStatus == SelectionStatus.INCLUDED.name &&
+                    it.extractionStatus == ExtractionStatus.EXCLUDED.name
+        }
+
+        val included = allStudies.filter {
+            it.selectionStatus == SelectionStatus.INCLUDED.name &&
+                    it.extractionStatus == ExtractionStatus.INCLUDED.name
+        }
+
+        val reviewData = ReviewExportData(
+            systematicStudy = systematicStudyDto!!.toExportData(),
+            protocol = protocolDto.toExportData(),
+            studiesExcludedInScreening = excludedInScreening.map { it.toExportData(extractionQuestions, robQuestions) },
+            studiesIncludedInScreening = includedInScreening.map { it.toExportData(extractionQuestions, robQuestions) },
+            studiesExcludedInFullText = excludedInFullText.map { it.toExportData(extractionQuestions, robQuestions) },
+            includedStudies = included.map { it.toExportData(extractionQuestions, robQuestions) },
+            funnel = FunnelCalculator.calculate(allStudies)
+        )
+
+        presenter.prepareSuccessView(
+            ExportReviewService.ResponseModel(
+                userId = request.userId,
+                systematicStudyId = request.systematicStudyId,
+                format = request.format,
+                formattedReview = exporter.export(reviewData)
+            )
+        )
+    }
+
+    private fun SystematicStudyDto.toExportData() = SystematicReviewExportData(
+        id = id,
+        title = title,
+        description = description,
+        owner = credentialsService.loadCredentials(owner)?.username ?: owner.toString(),
+        collaborators = collaborators.map { credentialsService.loadCredentials(it)?.username ?: it.toString() }.toSet(),
+        objectives = objectives
+    )
+
+    private fun ProtocolDto.toExportData() = ProtocolExportData(
+        id = id.toString(),
+        systematicStudy = systematicStudy.toString(),
+        goal = goal.orEmpty(),
+        justification = justification.orEmpty(),
+        researchQuestions = researchQuestions.toList(),
+        keywords = keywords.toList(),
+        searchString = searchString.orEmpty(),
+        informationSources = informationSources.toList(),
+        sourcesSelectionCriteria = sourcesSelectionCriteria.orEmpty(),
+        searchMethod = searchMethod.orEmpty(),
+        studiesLanguages = studiesLanguages.toList(),
+        studyTypeDefinition = studyTypeDefinition.orEmpty(),
+        selectionProcess = selectionProcess.orEmpty(),
+        eligibilityCriteria = eligibilityCriteria.map { CriterionExportData(it.description, it.type) },
+        dataCollectionProcess = dataCollectionProcess.orEmpty(),
+        analysisAndSynthesisProcess = analysisAndSynthesisProcess.orEmpty(),
+        extractionQuestions = extractionQuestions.map {
+            questionRepository.findById(systematicStudy, it)?.description ?: it.toString()
+        },
+        robQuestions = robQuestions.map {
+            questionRepository.findById(systematicStudy, it)?.description ?: it.toString()
+        },
+        picoc = picoc?.toExportData()
+    )
+
+    private fun PicocDto.toExportData() = PicocExportData(
+        population = population, intervention = intervention,
+        control = control, outcome = outcome, context = context
+    )
+
+    private fun StudyReviewDto.toExportData(
+        extractionQuestions: List<QuestionDto>,
+        robQuestions: List<QuestionDto>
+    ) = StudyExportData(
+        id = studyReviewId,
+        title = title,
+        authors = authors,
+        year = year,
+        venue = venue,
+        doi = doi,
+        keywords = keywords,
+        selectionCriteria = criteria,
+        extractionAnswers = extractionQuestions.map {
+            QuestionAnswerExportData(it.description, formAnswers[it.questionId])
+        },
+        robAnswers = robQuestions.map {
+            QuestionAnswerExportData(it.description, robAnswers[it.questionId])
+        }
+    )
+
+}

--- a/review/src/main/kotlin/br/all/application/report/find/service/StudiesFunnelServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/report/find/service/StudiesFunnelServiceImpl.kt
@@ -3,14 +3,12 @@ package br.all.application.report.find.service
 import br.all.application.report.find.presenter.StudiesFunnelPresenter
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.review.repository.fromDto
+import br.all.application.shared.presenter.FunnelCalculator
 import br.all.application.shared.presenter.prepareIfFailsPreconditions
 import br.all.application.study.repository.StudyReviewDto
 import br.all.application.study.repository.StudyReviewRepository
 import br.all.application.user.CredentialsService
 import br.all.domain.model.review.SystematicStudy
-import br.all.domain.model.study.ExtractionStatus
-import br.all.domain.model.study.SelectionStatus
-
 class StudiesFunnelServiceImpl(
     private val credentialsService: CredentialsService,
     private val studyReviewRepository: StudyReviewRepository,
@@ -32,63 +30,26 @@ class StudiesFunnelServiceImpl(
         presenter.prepareSuccessView(response)
     }
 
-    private fun createResponse(allStudies: List<StudyReviewDto>, request: StudiesFunnelService.RequestModel): StudiesFunnelService.ResponseModel {
-        val totalIdentifiedBySource = allStudies
-            .flatMap { it.searchSources }
-            .groupingBy { it }
-            .eachCount()
+    private fun createResponse(
+        allStudies: List<StudyReviewDto>,
+        request: StudiesFunnelService.RequestModel
+    ): StudiesFunnelService.ResponseModel {
+        val funnelData = FunnelCalculator.calculate(allStudies)
 
-        val nonDuplicatedStudies = allStudies.filter { it.selectionStatus != SelectionStatus.DUPLICATED.name }
-        val totalAfterDuplicatesRemovedBySource = nonDuplicatedStudies
-            .flatMap { it.searchSources }
-            .groupingBy { it }
-            .eachCount()
-
-        val totalScreened = allStudies.size
-
-        val totalExcludedInScreening = allStudies.count { it.selectionStatus == SelectionStatus.EXCLUDED.name }
-
-        val excludedByCriterion = allStudies
-            .filter { it.selectionStatus == SelectionStatus.EXCLUDED.name }
-            .flatMap { it.criteria }
-            .groupingBy { it }
-            .eachCount()
-
-        val totalFullTextAssessed = allStudies.count { 
-            it.selectionStatus == SelectionStatus.INCLUDED.name 
-        }
-
-        val totalExcludedInFullText = allStudies.count { 
-            it.selectionStatus == SelectionStatus.INCLUDED.name && 
-            it.extractionStatus == ExtractionStatus.EXCLUDED.name 
-        }
-
-        val totalExcludedByCriterion = allStudies
-            .filter { 
-                it.selectionStatus == SelectionStatus.INCLUDED.name && 
-                it.extractionStatus == ExtractionStatus.EXCLUDED.name 
-            }
-            .flatMap { it.criteria }
-            .groupingBy { it }
-            .eachCount()
-
-        val totalIncluded = allStudies.count { 
-            it.selectionStatus == SelectionStatus.INCLUDED.name && 
-            it.extractionStatus == ExtractionStatus.INCLUDED.name 
-        }
-
-        return StudiesFunnelService.ResponseModel(
+        val response = StudiesFunnelService.ResponseModel(
             userId = request.userId,
             systematicStudyId = request.systematicStudyId,
-            totalIdentifiedBySource = totalIdentifiedBySource,
-            totalAfterDuplicatesRemovedBySource = totalAfterDuplicatesRemovedBySource,
-            totalScreened = totalScreened,
-            totalExcludedInScreening = totalExcludedInScreening,
-            excludedByCriterion = excludedByCriterion,
-            totalFullTextAssessed = totalFullTextAssessed,
-            totalExcludedInFullText = totalExcludedInFullText,
-            totalExcludedByCriterion = totalExcludedByCriterion,
-            totalIncluded = totalIncluded
+            totalIdentifiedBySource = funnelData.totalIdentifiedBySource,
+            totalAfterDuplicatesRemovedBySource = funnelData.totalAfterDuplicatesRemovedBySource,
+            totalScreened = funnelData.totalScreened,
+            totalExcludedInScreening = funnelData.totalExcludedInScreening,
+            excludedByCriterion = funnelData.excludedByCriterion,
+            totalFullTextAssessed = funnelData.totalFullTextAssessed,
+            totalExcludedInFullText = funnelData.totalExcludedInFullText,
+            totalExcludedByCriterion = funnelData.totalExcludedByCriterion,
+            totalIncluded = funnelData.totalIncluded
         )
+        return response
+
     }
 }

--- a/review/src/main/kotlin/br/all/application/shared/presenter/FunnelCalculator.kt
+++ b/review/src/main/kotlin/br/all/application/shared/presenter/FunnelCalculator.kt
@@ -1,0 +1,33 @@
+package br.all.application.shared.presenter
+
+import br.all.application.report.export.FunnelExportData
+import br.all.application.study.repository.StudyReviewDto
+import br.all.domain.model.study.ExtractionStatus
+import br.all.domain.model.study.SelectionStatus
+
+object FunnelCalculator {
+    fun calculate(studies: List<StudyReviewDto>): FunnelExportData {
+        val nonDuplicated = studies.filter { it.selectionStatus != SelectionStatus.DUPLICATED.name }
+        return FunnelExportData(
+            totalIdentifiedBySource = studies.flatMap { it.searchSources }.groupingBy { it }.eachCount(),
+            totalAfterDuplicatesRemovedBySource = nonDuplicated.flatMap { it.searchSources }.groupingBy { it }.eachCount(),
+            totalScreened = studies.size,
+            totalExcludedInScreening = studies.count { it.selectionStatus == SelectionStatus.EXCLUDED.name },
+            excludedByCriterion = studies.filter { it.selectionStatus == SelectionStatus.EXCLUDED.name }
+                .flatMap { it.criteria }.groupingBy { it }.eachCount(),
+            totalFullTextAssessed = studies.count { it.selectionStatus == SelectionStatus.INCLUDED.name },
+            totalExcludedInFullText = studies.count {
+                it.selectionStatus == SelectionStatus.INCLUDED.name &&
+                        it.extractionStatus == ExtractionStatus.EXCLUDED.name
+            },
+            totalExcludedByCriterion = studies.filter {
+                it.selectionStatus == SelectionStatus.INCLUDED.name &&
+                        it.extractionStatus == ExtractionStatus.EXCLUDED.name
+            }.flatMap { it.criteria }.groupingBy { it }.eachCount(),
+            totalIncluded = studies.count {
+                it.selectionStatus == SelectionStatus.INCLUDED.name &&
+                        it.extractionStatus == ExtractionStatus.INCLUDED.name
+            }
+        )
+    }
+}

--- a/review/src/main/kotlin/br/all/infrastructure/report/export/DocumentBuilder.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/report/export/DocumentBuilder.kt
@@ -1,0 +1,19 @@
+package br.all.infrastructure.report.export
+
+import br.all.application.report.export.FunnelExportData
+import br.all.application.report.export.ProtocolExportData
+import br.all.application.report.export.StudyExportData
+import br.all.application.report.export.SystematicReviewExportData
+
+interface DocumentBuilder<T> {
+    fun addSystematicStudy(data: SystematicReviewExportData): DocumentBuilder<T>
+    fun addProtocol(data: ProtocolExportData): DocumentBuilder<T>
+    fun addFunnel(data: FunnelExportData): DocumentBuilder<T>
+    fun addStudies(
+        includedInScreening: List<StudyExportData>,
+        excludedInScreening: List<StudyExportData>,
+        included: List<StudyExportData>,
+        excludedInFullText: List<StudyExportData>,
+    ): DocumentBuilder<T>
+    fun build(): T
+}

--- a/review/src/main/kotlin/br/all/infrastructure/report/export/LatexDocumentBuilder.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/report/export/LatexDocumentBuilder.kt
@@ -10,6 +10,12 @@ class LatexDocumentBuilder : DocumentBuilder<String> {
 
     private val content = StringBuilder()
 
+    private val END_ITEMIZE = """\end{itemize}"""
+    private val BEGIN_ITEMIZE = """\begin{itemize}[leftmargin=*]"""
+    private val BEGIN_ITEMIZE_NESTED = """    \begin{itemize}"""
+    private val END_ITEMIZE_NESTED = """    \end{itemize}"""
+
+
     override fun addSystematicStudy(data: SystematicReviewExportData): DocumentBuilder<String> {
         content.appendLine("""\begin{center}""")
         content.appendLine("""{\LARGE \textbf{${escape(data.title)}}}""")
@@ -54,33 +60,33 @@ class LatexDocumentBuilder : DocumentBuilder<String> {
 
     override fun addFunnel(data: FunnelExportData): DocumentBuilder<String> {
         sectionHeader("Studies Funnel")
-        content.appendLine("""\begin{itemize}[leftmargin=*]""")
+        content.appendLine(BEGIN_ITEMIZE)
         content.appendLine("""    \item Total identified: ${data.totalIdentifiedBySource.values.sum()}""")
         content.appendLine("""    \item After duplicates removed: ${data.totalAfterDuplicatesRemovedBySource.values.sum()}""")
         content.appendLine("""    \item Screened: ${data.totalScreened}""")
 
         content.appendLine("""    \item Excluded in screening: ${data.totalExcludedInScreening}""")
         if (data.excludedByCriterion.isNotEmpty()) {
-            content.appendLine("""    \begin{itemize}""")
+            content.appendLine(BEGIN_ITEMIZE_NESTED)
             data.excludedByCriterion.forEach { (criterion, count) ->
                 content.appendLine("""        \item ${escape(criterion)}: $count""")
             }
-            content.appendLine("""    \end{itemize}""")
+            content.appendLine(END_ITEMIZE_NESTED)
         }
 
         content.appendLine("""    \item Full text assessed: ${data.totalFullTextAssessed}""")
 
         content.appendLine("""    \item Excluded in full text: ${data.totalExcludedInFullText}""")
         if (data.totalExcludedByCriterion.isNotEmpty()) {
-            content.appendLine("""    \begin{itemize}""")
+            content.appendLine(BEGIN_ITEMIZE_NESTED)
             data.totalExcludedByCriterion.forEach { (criterion, count) ->
                 content.appendLine("""        \item ${escape(criterion)}: $count""")
             }
-            content.appendLine("""    \end{itemize}""")
+            content.appendLine(END_ITEMIZE_NESTED)
         }
         content.appendLine("""    \item Included: ${data.totalIncluded}""")
 
-        content.appendLine("""\end{itemize}""")
+        content.appendLine(END_ITEMIZE)
         return this
     }
 
@@ -136,9 +142,9 @@ class LatexDocumentBuilder : DocumentBuilder<String> {
         fields.filter { it.second.isNotEmpty() }.forEach { (title, items) ->
             content.appendLine()
             content.appendLine("""\medskip\noindent\textbf{${escape(title)}}""")
-            content.appendLine("""\begin{itemize}[leftmargin=*]""")
+            content.appendLine(BEGIN_ITEMIZE)
             items.forEach { content.appendLine("""    \item ${escape(it)}""") }
-            content.appendLine("""\end{itemize}""")
+            content.appendLine(END_ITEMIZE)
         }
 
         return this
@@ -161,24 +167,24 @@ class LatexDocumentBuilder : DocumentBuilder<String> {
     private fun subsectionWithList(title: String, items: List<String>) {
         if (items.isEmpty()) return
         content.appendLine("""\subsection{${escape(title)}}""")
-        content.appendLine("""\begin{itemize}[leftmargin=*]""")
+        content.appendLine(BEGIN_ITEMIZE)
         items.forEach { content.appendLine("""    \item ${escape(it)}""") }
-        content.appendLine("""\end{itemize}""")
+        content.appendLine(END_ITEMIZE)
     }
 
     private fun sectionWithStudyList(title: String, studies: List<StudyExportData>) {
         if (studies.isEmpty()) return
         content.appendLine("""\section{${escape(title)}}""")
-        content.appendLine("""\begin{itemize}[leftmargin=*]""")
+        content.appendLine(BEGIN_ITEMIZE)
         studies.forEach { study ->
             content.appendLine("""    \item ${escape(study.title)} (${study.year})""")
             if (study.selectionCriteria.isNotEmpty()) {
-                content.appendLine("""    \begin{itemize}""")
+                content.appendLine(BEGIN_ITEMIZE_NESTED)
                 content.appendLine("""        \item ${study.selectionCriteria.joinToString(", ")}""")
-                content.appendLine("""    \end{itemize}""")
+                content.appendLine(END_ITEMIZE_NESTED)
             }
         }
-        content.appendLine("""\end{itemize}""")
+        content.appendLine(END_ITEMIZE)
     }
 
     private fun escape(text: String): String {

--- a/review/src/main/kotlin/br/all/infrastructure/report/export/LatexDocumentBuilder.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/report/export/LatexDocumentBuilder.kt
@@ -1,0 +1,194 @@
+package br.all.infrastructure.report.export
+
+import br.all.application.report.export.FunnelExportData
+import br.all.application.report.export.PicocExportData
+import br.all.application.report.export.ProtocolExportData
+import br.all.application.report.export.StudyExportData
+import br.all.application.report.export.SystematicReviewExportData
+
+class LatexDocumentBuilder : DocumentBuilder<String> {
+
+    private val content = StringBuilder()
+
+    override fun addSystematicStudy(data: SystematicReviewExportData): DocumentBuilder<String> {
+        content.appendLine("""\begin{center}""")
+        content.appendLine("""{\LARGE \textbf{${escape(data.title)}}}""")
+        content.appendLine("""\end{center}""")
+        content.appendLine("""\noindent\rule{\textwidth}{0.4pt}""")
+        content.appendLine("""\vspace{0.5em}""")
+        content.appendLine(escape(data.description))
+        content.appendLine()
+        content.appendLine("""\medskip\noindent\textbf{Objectives:} ${escape(data.objectives)}""")
+        content.appendLine()
+        content.appendLine("""\medskip\noindent\textbf{Owner:} ${data.owner}""")
+        if (data.collaborators.isNotEmpty()) {
+            content.appendLine()
+            content.appendLine("""\medskip\noindent\textbf{Collaborators:} ${data.collaborators.joinToString(", ")}""")
+        }
+        content.appendLine("""\vspace{1em}""")
+        return this
+    }
+
+    override fun addProtocol(data: ProtocolExportData): DocumentBuilder<String> {
+        sectionHeader("Protocol")
+        subsection("Goal", data.goal)
+        subsection("Justification", data.justification)
+        subsectionWithList("Research Questions", data.researchQuestions)
+        subsectionWithList("Keywords", data.keywords)
+        subsection("Search String", data.searchString)
+        subsectionWithList("Information Sources", data.informationSources)
+        subsection("Sources Selection Criteria", data.sourcesSelectionCriteria)
+        subsection("Search Method", data.searchMethod)
+        subsectionWithList("Studies Languages", data.studiesLanguages)
+        subsection("Study Type Definition", data.studyTypeDefinition)
+        subsection("Selection Process", data.selectionProcess)
+        subsectionWithList("Inclusion Criteria", data.inclusionCriteria())
+        subsectionWithList("Exclusion Criteria", data.exclusionCriteria())
+        subsection("Data Collection Process", data.dataCollectionProcess)
+        subsection("Analysis and Synthesis Process", data.analysisAndSynthesisProcess)
+        subsectionWithList("Extraction Questions", data.extractionQuestions)
+        subsectionWithList("Risk of Bias Questions", data.robQuestions)
+        picoc(data.picoc)
+        return this
+    }
+
+    override fun addFunnel(data: FunnelExportData): DocumentBuilder<String> {
+        sectionHeader("Studies Funnel")
+        content.appendLine("""\begin{itemize}[leftmargin=*]""")
+        content.appendLine("""    \item Total identified: ${data.totalIdentifiedBySource.values.sum()}""")
+        content.appendLine("""    \item After duplicates removed: ${data.totalAfterDuplicatesRemovedBySource.values.sum()}""")
+        content.appendLine("""    \item Screened: ${data.totalScreened}""")
+
+        content.appendLine("""    \item Excluded in screening: ${data.totalExcludedInScreening}""")
+        if (data.excludedByCriterion.isNotEmpty()) {
+            content.appendLine("""    \begin{itemize}""")
+            data.excludedByCriterion.forEach { (criterion, count) ->
+                content.appendLine("""        \item ${escape(criterion)}: $count""")
+            }
+            content.appendLine("""    \end{itemize}""")
+        }
+
+        content.appendLine("""    \item Full text assessed: ${data.totalFullTextAssessed}""")
+
+        content.appendLine("""    \item Excluded in full text: ${data.totalExcludedInFullText}""")
+        if (data.totalExcludedByCriterion.isNotEmpty()) {
+            content.appendLine("""    \begin{itemize}""")
+            data.totalExcludedByCriterion.forEach { (criterion, count) ->
+                content.appendLine("""        \item ${escape(criterion)}: $count""")
+            }
+            content.appendLine("""    \end{itemize}""")
+        }
+        content.appendLine("""    \item Included: ${data.totalIncluded}""")
+
+        content.appendLine("""\end{itemize}""")
+        return this
+    }
+
+    override fun addStudies(
+        includedInScreening: List<StudyExportData>,
+        excludedInScreening: List<StudyExportData>,
+        included: List<StudyExportData>,
+        excludedInFullText: List<StudyExportData>,
+    ): DocumentBuilder<String> {
+
+        sectionWithStudyList("Studies Included in Screening", includedInScreening)
+        sectionWithStudyList("Studies Excluded in Screening", excludedInScreening)
+
+        sectionHeader("Included Studies")
+        included.forEach { addStudyIncludedInExtraction(it) }
+
+        sectionWithStudyList("Studies Excluded in Full Text", excludedInFullText)
+
+        return this
+    }
+
+    override fun build(): String = buildString {
+        appendLine("""\documentclass{article}""")
+        appendLine("""\usepackage[utf8]{inputenc}""")
+        appendLine("""\usepackage{enumitem}""")
+        appendLine("""\begin{document}""")
+        append(content)
+        appendLine("""\end{document}""")
+    }
+
+    private fun picoc(picoc: PicocExportData?) {
+        if (picoc == null) return
+        val items = listOfNotNull(
+            picoc.population?.let { "Population: $it" },
+            picoc.intervention?.let { "Intervention: $it" },
+            picoc.control?.let { "Control: $it" },
+            picoc.outcome?.let { "Outcome: $it" },
+            picoc.context?.let { "Context: $it" },
+        )
+        subsectionWithList("PICOC", items)
+    }
+
+
+    private fun addStudyIncludedInExtraction(data: StudyExportData): DocumentBuilder<String> {
+        content.appendLine("""\subsection*{${escape(data.title)} (${data.year})}""")
+        content.appendLine("""\noindent ${escape(data.authors)}. ${escape(data.venue)}""")
+
+        val fields = listOf(
+            "Selection Criteria" to data.selectionCriteria.toList(),
+            "Extraction Answers" to data.extractionAnswers.map { "${it.question}: ${it.answer ?: "N/A"}" },
+            "Risk of Bias Answers" to data.robAnswers.map { "${it.question}: ${it.answer ?: "N/A"}" },
+        )
+        fields.filter { it.second.isNotEmpty() }.forEach { (title, items) ->
+            content.appendLine()
+            content.appendLine("""\medskip\noindent\textbf{${escape(title)}}""")
+            content.appendLine("""\begin{itemize}[leftmargin=*]""")
+            items.forEach { content.appendLine("""    \item ${escape(it)}""") }
+            content.appendLine("""\end{itemize}""")
+        }
+
+        return this
+    }
+
+
+
+
+
+    private fun sectionHeader(title: String) {
+        content.appendLine("""\section{${escape(title)}}""")
+    }
+
+    private fun subsection(title: String, text: String) {
+        if (text.isBlank()) return
+        content.appendLine("""\subsection{${escape(title)}}""")
+        content.appendLine(escape(text))
+    }
+
+    private fun subsectionWithList(title: String, items: List<String>) {
+        if (items.isEmpty()) return
+        content.appendLine("""\subsection{${escape(title)}}""")
+        content.appendLine("""\begin{itemize}[leftmargin=*]""")
+        items.forEach { content.appendLine("""    \item ${escape(it)}""") }
+        content.appendLine("""\end{itemize}""")
+    }
+
+    private fun sectionWithStudyList(title: String, studies: List<StudyExportData>) {
+        if (studies.isEmpty()) return
+        content.appendLine("""\section{${escape(title)}}""")
+        content.appendLine("""\begin{itemize}[leftmargin=*]""")
+        studies.forEach { study ->
+            content.appendLine("""    \item ${escape(study.title)} (${study.year})""")
+            if (study.selectionCriteria.isNotEmpty()) {
+                content.appendLine("""    \begin{itemize}""")
+                content.appendLine("""        \item ${study.selectionCriteria.joinToString(", ")}""")
+                content.appendLine("""    \end{itemize}""")
+            }
+        }
+        content.appendLine("""\end{itemize}""")
+    }
+
+    private fun escape(text: String): String {
+        return text.replace("\\", """\textbackslash{}""")
+            .replace("_", """\_""")
+            .replace("%", """\%""")
+            .replace("&", """\&""")
+            .replace("#", """\#""")
+            .replace("{", """\{""")
+            .replace("}", """\}""")
+            .replace("$", """\$""")
+    }
+}

--- a/review/src/main/kotlin/br/all/infrastructure/report/export/LatexReviewExporter.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/report/export/LatexReviewExporter.kt
@@ -1,0 +1,23 @@
+package br.all.infrastructure.report.export
+
+import br.all.application.report.export.ReviewExportData
+import br.all.application.report.export.ReviewExporter
+
+class LatexReviewExporter: ReviewExporter{
+    override val format = "latex"
+
+    override fun export(data: ReviewExportData): String {
+         return LatexDocumentBuilder()
+            .addSystematicStudy(data.systematicStudy)
+            .addProtocol(data.protocol)
+            .addFunnel(data.funnel)
+             .addStudies(
+                 data.studiesIncludedInScreening,
+                 data.studiesExcludedInScreening,
+                 data.includedStudies,
+                 data.studiesExcludedInFullText,
+
+             )
+             .build()
+    }
+}

--- a/review/src/test/kotlin/br/all/application/report/export/ExportReviewServiceImplTest.kt
+++ b/review/src/test/kotlin/br/all/application/report/export/ExportReviewServiceImplTest.kt
@@ -1,0 +1,259 @@
+package br.all.application.report.export
+
+import br.all.application.protocol.repository.ProtocolRepository
+import br.all.application.protocol.util.TestDataFactory as ProtocolTestDataFactory
+import br.all.application.study.util.TestDataFactory as StudyTestDataFactory
+import br.all.application.question.repository.QuestionRepository
+import br.all.application.report.export.presenter.ExportReviewPresenter
+import br.all.application.report.export.service.ExportReviewService
+import br.all.application.report.export.service.ExportReviewServiceImpl
+import br.all.application.review.repository.SystematicStudyRepository
+import br.all.application.study.repository.StudyReviewRepository
+import br.all.application.user.CredentialsService
+import br.all.application.util.PreconditionCheckerMockingNew
+import br.all.domain.shared.exception.EntityNotFoundException
+import br.all.domain.shared.exception.UnauthenticatedUserException
+import br.all.domain.shared.exception.UnauthorizedUserException
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+import kotlin.test.assertEquals
+
+@Tag("UnitTest")
+@Tag("ServiceTest")
+@ExtendWith(MockKExtension::class)
+class ExportReviewServiceImplTest {
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var systematicStudyRepository: SystematicStudyRepository
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var protocolRepository: ProtocolRepository
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var studyReviewRepository: StudyReviewRepository
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var questionRepository: QuestionRepository
+
+    @MockK
+    private lateinit var credentialsService: CredentialsService
+
+    @MockK
+    private lateinit var reviewExporter: ReviewExporter
+
+    @MockK(relaxed = true)
+    private lateinit var presenter: ExportReviewPresenter
+
+    private lateinit var sut: ExportReviewServiceImpl
+    private lateinit var precondition: PreconditionCheckerMockingNew
+    private lateinit var protocolFactory: ProtocolTestDataFactory
+    private lateinit var studyFactory: StudyTestDataFactory
+
+    private lateinit var researcherId: UUID
+    private lateinit var systematicStudyId: UUID
+
+    @BeforeEach
+    fun setup() {
+        protocolFactory = ProtocolTestDataFactory()
+        studyFactory = StudyTestDataFactory()
+
+        researcherId = protocolFactory.researcher
+        systematicStudyId = protocolFactory.systematicStudy
+
+        every { reviewExporter.format } returns "latex"
+        every { reviewExporter.export(any()) } returns "\\documentclass{article}\\begin{document}Review Content\\end{document}"
+        every { questionRepository.findAllBySystematicStudyId(any(), any()) } returns emptyList()
+
+        sut = ExportReviewServiceImpl(
+            credentialsService,
+            systematicStudyRepository,
+            protocolRepository,
+            studyReviewRepository,
+            questionRepository,
+            mapOf("latex" to reviewExporter)
+        )
+
+        precondition = PreconditionCheckerMockingNew(
+            presenter,
+            credentialsService,
+            systematicStudyRepository,
+            researcherId,
+            systematicStudyId
+        )
+    }
+
+    @Nested
+    @Tag("ValidClasses")
+    @DisplayName("When being successful")
+    inner class WhenBeingSuccessful {
+
+        @Test
+        fun `should export review in latex format`() {
+            val protocolDto = protocolFactory.protocolDto()
+            val output = "\\documentclass{article}\\begin{document}Review Content\\end{document}"
+
+            precondition.makeEverythingWork()
+            every { protocolRepository.findById(systematicStudyId) } returns protocolDto
+            every { studyReviewRepository.findAllFromReview(systematicStudyId) } returns emptyList()
+            every { reviewExporter.export(any()) } returns output
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            val expectedResponse = ExportReviewService.ResponseModel(
+                researcherId, systematicStudyId, "latex", output
+            )
+            verify(exactly = 1) { presenter.prepareSuccessView(expectedResponse) }
+        }
+
+        @Test
+        fun `should return empty study lists when there are no studies`() {
+            val protocolDto = protocolFactory.protocolDto()
+            val slot = slot<ReviewExportData>()
+
+            precondition.makeEverythingWork()
+            every { protocolRepository.findById(systematicStudyId) } returns protocolDto
+            every { studyReviewRepository.findAllFromReview(systematicStudyId) } returns emptyList()
+            every { reviewExporter.export(capture(slot)) } returns "content"
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            val reviewData = slot.captured
+            assertEquals(0, reviewData.studiesExcludedInScreening.size)
+            assertEquals(0, reviewData.studiesIncludedInScreening.size)
+            assertEquals(0, reviewData.studiesExcludedInFullText.size)
+            assertEquals(0, reviewData.includedStudies.size)
+        }
+
+        @Test
+        fun `should correctly separate studies by stage`() {
+            val protocolDto = protocolFactory.protocolDto()
+            val slot = slot<ReviewExportData>()
+
+            val studyExcludedInScreening = studyFactory.generateDto(
+                systematicStudyId = systematicStudyId, studyReviewId = 1L,
+                selectionStatus = "EXCLUDED", extractionStatus = "UNCLASSIFIED"
+            )
+            val studyIncludedInScreening = studyFactory.generateDto(
+                systematicStudyId = systematicStudyId, studyReviewId = 2L,
+                selectionStatus = "INCLUDED", extractionStatus = "UNCLASSIFIED"
+            )
+            val studyExcludedInFullText = studyFactory.generateDto(
+                systematicStudyId = systematicStudyId, studyReviewId = 3L,
+                selectionStatus = "INCLUDED", extractionStatus = "EXCLUDED"
+            )
+            val studyFullyIncluded = studyFactory.generateDto(
+                systematicStudyId = systematicStudyId, studyReviewId = 4L,
+                selectionStatus = "INCLUDED", extractionStatus = "INCLUDED"
+            )
+
+            precondition.makeEverythingWork()
+            every { protocolRepository.findById(systematicStudyId) } returns protocolDto
+            every { studyReviewRepository.findAllFromReview(systematicStudyId) } returns listOf(
+                studyExcludedInScreening, studyIncludedInScreening, studyExcludedInFullText, studyFullyIncluded
+            )
+            every { reviewExporter.export(capture(slot)) } returns "content"
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            val reviewData = slot.captured
+            assertEquals(1, reviewData.studiesExcludedInScreening.size)
+            assertEquals(3, reviewData.studiesIncludedInScreening.size)
+            assertEquals(1, reviewData.studiesExcludedInFullText.size)
+            assertEquals(1, reviewData.includedStudies.size)
+        }
+
+        @Test
+        fun `should calculate funnel from all studies`() {
+            val protocolDto = protocolFactory.protocolDto()
+            val slot = slot<ReviewExportData>()
+
+            val studies = listOf(
+                studyFactory.generateDto(systematicStudyId = systematicStudyId, studyReviewId = 1L,
+                    selectionStatus = "EXCLUDED", extractionStatus = "UNCLASSIFIED"),
+                studyFactory.generateDto(systematicStudyId = systematicStudyId, studyReviewId = 2L,
+                    selectionStatus = "INCLUDED", extractionStatus = "INCLUDED"),
+            )
+
+            precondition.makeEverythingWork()
+            every { protocolRepository.findById(systematicStudyId) } returns protocolDto
+            every { studyReviewRepository.findAllFromReview(systematicStudyId) } returns studies
+            every { reviewExporter.export(capture(slot)) } returns "content"
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            assertEquals(1, slot.captured.funnel.totalIncluded)
+        }
+    }
+
+    @Nested
+    @Tag("InvalidClasses")
+    @DisplayName("When being unsuccessful")
+    inner class WhenBeingUnsuccessful {
+
+        @Test
+        fun `should fail when format is unsupported`() {
+            precondition.makeEverythingWork()
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "pdf")
+            sut.exportReview(presenter, request)
+
+            verify(exactly = 1) {
+                presenter.prepareFailView(match<EntityNotFoundException> { it.message == "Invalid export format pdf" })
+            }
+        }
+
+        @Test
+        fun `should fail when systematic study does not exist`() {
+            precondition.makeSystematicStudyNonexistent()
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            verifyOrder {
+                presenter.prepareFailView(any<EntityNotFoundException>())
+                presenter.isDone()
+            }
+        }
+
+        @Test
+        fun `should fail when user is unauthenticated`() {
+            precondition.makeUserUnauthenticated()
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            verifyOrder {
+                presenter.prepareFailView(any<UnauthenticatedUserException>())
+                presenter.isDone()
+            }
+        }
+
+        @Test
+        fun `should fail when user is unauthorized`() {
+            precondition.makeUserUnauthorized()
+
+            val request = ExportReviewService.RequestModel(researcherId, systematicStudyId, "latex")
+            sut.exportReview(presenter, request)
+
+            verifyOrder {
+                presenter.prepareFailView(any<UnauthorizedUserException>())
+                presenter.isDone()
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/br/all/report/controller/ReportController.kt
+++ b/web/src/main/kotlin/br/all/report/controller/ReportController.kt
@@ -1,5 +1,7 @@
 package br.all.report.controller
 
+import br.all.application.report.find.service.ExportProtocolService
+import br.all.application.report.export.service.ExportReviewService
 import br.all.application.report.find.service.*
 import br.all.report.presenter.*
 import br.all.security.service.AuthenticationInfoService
@@ -33,7 +35,8 @@ class ReportController(
     private val findAnswerService: FindAnswerServiceImpl,
     private val studiesFunnelService: StudiesFunnelService,
     private val authenticationInfoService: AuthenticationInfoService,
-    private val linksFactory: LinksFactory
+    private val exportReviewService: ExportReviewService,
+    private val linksFactory: LinksFactory,
 ) {
 
     @GetMapping("{studyReviewId}/included-studies-answers")
@@ -380,4 +383,49 @@ class ReportController(
         findStudyReviewCriteriaService.findCriteria(presenter, request)
         return presenter.responseEntity ?: ResponseEntity<Void>(HttpStatus.INTERNAL_SERVER_ERROR)
     }
+
+
+    @GetMapping("exportable-review/{format}")
+    @Operation(summary = "Export Review")
+    @ApiResponses(
+        value =[
+            ApiResponse(responseCode = "200", description = "Success exporting formatted review",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = RestfulExportReviewPresenter::class)
+                    )
+                ]),
+
+            ApiResponse(responseCode = "401", description = "Unauthenticated user",
+                content = [Content(schema = Schema(hidden = true))]),
+            ApiResponse(responseCode = "403", description = "Unauthorized user",
+                content = [Content(schema = Schema(hidden = true))])
+
+
+
+        ]
+    )
+    fun exportReview(
+        @PathVariable systematicStudyId: UUID,
+        @PathVariable format: String,
+        @RequestParam downloadable: Boolean
+    ): ResponseEntity<*>{
+        val presenter = if (downloadable) {
+            DownloadableReviewPresenter()
+        } else {
+            RestfulExportReviewPresenter(linksFactory)
+        }
+        val userId = authenticationInfoService.getAuthenticatedUserId()
+        val request = ExportReviewService.RequestModel(userId,systematicStudyId,format.lowercase())
+        exportReviewService.exportReview(presenter,request)
+        val responseEntity = when (presenter) {
+            is DownloadableReviewPresenter -> presenter.responseEntity
+            is RestfulExportReviewPresenter -> presenter.responseEntity
+            else -> null
+        }
+        return responseEntity ?: ResponseEntity<Void>(HttpStatus.INTERNAL_SERVER_ERROR)
+    }
 }
+
+

--- a/web/src/main/kotlin/br/all/report/controller/ReportControllerConfiguration.kt
+++ b/web/src/main/kotlin/br/all/report/controller/ReportControllerConfiguration.kt
@@ -3,9 +3,12 @@ package br.all.report.controller
 import br.all.application.protocol.repository.ProtocolRepository
 import br.all.application.question.repository.QuestionRepository
 import br.all.application.report.find.service.*
+import br.all.application.report.find.service.ExportProtocolServiceImpl
+import br.all.application.report.export.service.ExportReviewServiceImpl
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.study.repository.StudyReviewRepository
 import br.all.application.user.CredentialsService
+import br.all.infrastructure.report.export.LatexReviewExporter
 import br.all.domain.services.CsvFormatterService
 import br.all.domain.services.FormatterFactoryService
 import br.all.domain.services.LatexFormatterService
@@ -28,6 +31,31 @@ class ReportControllerConfiguration {
         csvFormatterService,
         latexFormatterService
     )
+
+
+    @Bean
+    fun latexReviewExporter() = LatexReviewExporter()
+
+
+    @Bean
+    fun exportReviewService(
+        credentialsService: CredentialsService,
+        protocolRepository: ProtocolRepository,
+        systematicStudyRepository: SystematicStudyRepository,
+        studyReviewRepository: StudyReviewRepository,
+        questionRepository: QuestionRepository,
+        latexReviewExporter: LatexReviewExporter
+    ) = ExportReviewServiceImpl(
+        credentialsService,
+        systematicStudyRepository,
+        protocolRepository,
+        studyReviewRepository,
+        questionRepository,
+        mapOf(latexReviewExporter.format to latexReviewExporter)
+    )
+
+
+
 
     @Bean
     fun includedStudiesAnswersService(

--- a/web/src/main/kotlin/br/all/report/presenter/DownloadablePresenter.kt
+++ b/web/src/main/kotlin/br/all/report/presenter/DownloadablePresenter.kt
@@ -1,0 +1,39 @@
+package br.all.report.presenter
+
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+
+import java.util.UUID
+
+fun buildDownloadResponse(
+    format: String,
+    systematicStudyId: UUID,
+    prefix: String,
+    content: String
+): ResponseEntity<*> {
+    val fileExtension = when (format.lowercase()) {
+        "latex" -> "tex"
+        "csv" -> "csv"
+        "json" -> "json"
+        "pdf" -> "pdf"
+        else -> "txt"
+    }
+    val mediaType = when (format.lowercase()) {
+        "latex" -> "application/x-latex"
+        "csv" -> "text/csv"
+        "json" -> "application/json"
+        "pdf" -> "application/pdf"
+        else -> "text/plain"
+    }
+    val resource = ByteArrayResource(content.toByteArray(Charsets.UTF_8))
+    val headers = HttpHeaders().apply {
+        add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"${prefix}_$systematicStudyId.$fileExtension\"")
+        contentType = MediaType.parseMediaType(mediaType)
+    }
+    return ResponseEntity.status(HttpStatus.OK).headers(headers).body(resource)
+}
+

--- a/web/src/main/kotlin/br/all/report/presenter/DownloadableProtocolPresenter.kt
+++ b/web/src/main/kotlin/br/all/report/presenter/DownloadableProtocolPresenter.kt
@@ -3,10 +3,6 @@ package br.all.report.presenter
 import br.all.application.report.find.presenter.ExportProtocolPresenter
 import br.all.application.report.find.service.ExportProtocolService
 import br.all.shared.error.createErrorResponseFrom
-import org.springframework.core.io.ByteArrayResource
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 
 class DownloadableProtocolPresenter : ExportProtocolPresenter {
@@ -14,32 +10,12 @@ class DownloadableProtocolPresenter : ExportProtocolPresenter {
     var responseEntity: ResponseEntity<*>? = null
 
     override fun prepareSuccessView(response: ExportProtocolService.ResponseModel) {
-        val fileExtension = when (response.format.lowercase()) {
-            "latex" -> "tex"
-            "csv" -> "csv"
-            "json" -> "json"
-            "pdf" -> "pdf"
-            else -> "txt"
-        }
-
-        val mediaType = when (response.format.lowercase()) {
-            "latex" -> "application/x-latex"
-            "csv" -> "text/csv"
-            "json" -> "application/json"
-            "pdf" -> "application/pdf"
-            else -> "text/plain"
-        }
-
-        val filename = "protocol_${response.systematicStudyId}.$fileExtension"
-
-        val resource = ByteArrayResource(response.formattedProtocol.toByteArray(Charsets.UTF_8))
-
-        val headers = HttpHeaders().apply {
-            add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
-            contentType = MediaType.parseMediaType(mediaType)
-        }
-
-        responseEntity = ResponseEntity.status(HttpStatus.OK).headers(headers).body(resource)
+        responseEntity = buildDownloadResponse(
+            format = response.format,
+            systematicStudyId = response.systematicStudyId,
+            prefix = "protocol",
+            content = response.formattedProtocol
+        )
     }
 
     override fun prepareFailView(throwable: Throwable) {

--- a/web/src/main/kotlin/br/all/report/presenter/DownloadableReviewPresenter.kt
+++ b/web/src/main/kotlin/br/all/report/presenter/DownloadableReviewPresenter.kt
@@ -1,0 +1,27 @@
+package br.all.report.presenter
+
+import br.all.application.report.export.presenter.ExportReviewPresenter
+import br.all.application.report.export.service.ExportReviewService
+import br.all.shared.error.createErrorResponseFrom
+import org.springframework.http.ResponseEntity
+
+class DownloadableReviewPresenter : ExportReviewPresenter {
+
+    var responseEntity: ResponseEntity<*>? = null
+
+    override fun prepareSuccessView(response: ExportReviewService.ResponseModel) {
+        responseEntity = buildDownloadResponse(
+            response.format,
+            response.systematicStudyId,
+            "review",
+            response.formattedReview
+        )
+    }
+
+    override fun prepareFailView(throwable: Throwable) {
+        responseEntity = createErrorResponseFrom(throwable)
+    }
+
+    override fun isDone() = responseEntity != null
+}
+

--- a/web/src/main/kotlin/br/all/report/presenter/RestfulExportReviewPresenter.kt
+++ b/web/src/main/kotlin/br/all/report/presenter/RestfulExportReviewPresenter.kt
@@ -1,0 +1,40 @@
+package br.all.report.presenter
+
+import br.all.application.report.export.presenter.ExportReviewPresenter
+import br.all.application.report.export.service.ExportReviewService
+import br.all.shared.error.createErrorResponseFrom
+import br.all.utils.LinksFactory
+import org.springframework.hateoas.RepresentationModel
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.util.UUID
+
+class RestfulExportReviewPresenter(
+    private val linkFactory: LinksFactory
+) : ExportReviewPresenter {
+    var responseEntity: ResponseEntity<*>? = null
+
+    override fun prepareSuccessView(response: ExportReviewService.ResponseModel) {
+        val restfulResponse = ViewModel(
+            response.userId,
+            response.systematicStudyId,
+            response.formattedReview
+        )
+        val selfRef = linkFactory.exportReview(response.systematicStudyId,response.format, downloadable = true)
+        restfulResponse.add(selfRef)
+        responseEntity = ResponseEntity.status(HttpStatus.OK).body(restfulResponse)
+
+    }
+
+    override fun prepareFailView(throwable: Throwable)  = run {responseEntity = createErrorResponseFrom(throwable)}
+
+
+    override fun isDone() = responseEntity != null
+
+
+    data class ViewModel(
+        val userId: UUID,
+        val systematicStudyId: UUID,
+        val formattedReview: String
+    ): RepresentationModel<ViewModel>()
+}

--- a/web/src/main/kotlin/br/all/utils/LinksFactory.kt
+++ b/web/src/main/kotlin/br/all/utils/LinksFactory.kt
@@ -426,4 +426,19 @@ class LinksFactory {
                 request
             )
         }.withRel("remove-criteria").withType("PATCH")
+
+    fun exportReview(systematicStudyId: UUID, format: String,downloadable: Boolean): Link{
+       val uri = linkTo<ReportController> {
+           exportReview(systematicStudyId,format,downloadable)
+       }.toUriComponentsBuilder()
+           .queryParam("downloadable",downloadable)
+           .build()
+           .toUri()
+
+        return Link.of(uri.toString())
+            .withRel("exportable-review")
+            .withType("GET")
+    }
+
+
 }

--- a/web/src/test/kotlin/br/all/report/controller/ReportControllerTest.kt
+++ b/web/src/test/kotlin/br/all/report/controller/ReportControllerTest.kt
@@ -61,6 +61,7 @@ class ReportControllerTest(
         user = testHelperService.createApplicationUser()
 
         systematicStudy = systematicStudyDataFactory.createSystematicStudyDocument(
+            owner = user.id,
             collaborators = mutableSetOf(user.id)
         )
 
@@ -126,6 +127,9 @@ class ReportControllerTest(
             "$baseReportUrl/keywords"
         else
             "$baseReportUrl/keywords?filter=$filter"
+
+    private fun exportReviewUrl(format: String, downloadable: Boolean = false) =
+        "$baseReportUrl/exportable-review/$format?downloadable=$downloadable"
 
     @Nested
     @DisplayName("When searching answers of questions")
@@ -733,6 +737,69 @@ class ReportControllerTest(
                     .with(SecurityMockMvcRequestPostProcessors.user(user))
             )
                 .andExpect(status().isOk)
+        }
+    }
+
+    @Nested
+    @DisplayName("When exporting review")
+    inner class WhenExportingReview {
+
+        @Nested
+        @DisplayName("And having success")
+        inner class AndHavingSuccess {
+            @Test
+            fun `should return 200 when exporting review in latex format`() {
+                val protocol = protocolDataFactory.createProtocolDocument(id = systematicStudy.id)
+                protocolRepository.save(protocol)
+
+                mockMvc.perform(
+                    get(exportReviewUrl(format = "latex"))
+                        .with(SecurityMockMvcRequestPostProcessors.user(user))
+                )
+                    .andExpect(status().isOk)
+            }
+        }
+
+        @Nested
+        @DisplayName("And failing")
+        inner class AndFailing {
+            @Test
+            fun `should return 404 when format is unsupported`() {
+                val protocol = protocolDataFactory.createProtocolDocument(id = systematicStudy.id)
+                protocolRepository.save(protocol)
+
+                mockMvc.perform(
+                    get(exportReviewUrl(format = "pdf"))
+                        .with(SecurityMockMvcRequestPostProcessors.user(user))
+                )
+                    .andExpect(status().isNotFound)
+            }
+
+            @Test
+            fun `should return 404 when systematic study does not exist`() {
+                mockMvc.perform(
+                    get(
+                        "/api/v1/systematic-study/${UUID.randomUUID()}/report/exportable-review/latex?downloadable=false"
+                    ).with(SecurityMockMvcRequestPostProcessors.user(user))
+                )
+                    .andExpect(status().isNotFound)
+            }
+
+            @Test
+            fun `should not allow unauthenticated user to export review`() {
+                testHelperService.testForUnauthenticatedUser(
+                    mockMvc = mockMvc,
+                    requestBuilder = get(exportReviewUrl(format = "latex"))
+                )
+            }
+
+            @Test
+            fun `should not allow unauthorized user to export review`() {
+                testHelperService.testForUnauthorizedUser(
+                    mockMvc = mockMvc,
+                    requestBuilder = get(exportReviewUrl(format = "latex"))
+                )
+            }
         }
     }
 }


### PR DESCRIPTION

 ## Resumo
                                                                                                                                                                                                    
  Este PR adiciona a funcionalidade de exportar uma revisão sistemática completa no formato LaTeX, incluindo:
  - Metadados da revisão (título, descrição, objetivos, responsável, colaboradores)
  - Detalhes do protocolo (questões de pesquisa, palavras-chave, critérios, PICOC, etc.)
  - Funil de estudos com exclusões detalhadas por critério
  - Estudos separados por etapa (incluídos na triagem, excluídos na triagem, excluídos no full text, incluídos)
  - Respostas de extração e risco de viés dos estudos incluídos

  ## Mudanças

  ### Camada de aplicação
  - Adicionados modelos de dados de exportação (`FunnelExportData`, `StudyExportData`, `SystematicStudyExportData`, `ReviewExportData`, `ProtocolExportData`)
  - Adicionados contratos `ReviewExporter`, `ExportReviewService` e `ExportReviewPresenter`
  - Adicionado `ExportReviewServiceImpl` usando Strategy pattern via `Map<String, ReviewExporter>`
  - Extraído cálculo do funil para `FunnelCalculator` (reutilizado pelo `StudiesFunnelServiceImpl`)

  ### Camada de infraestrutura
  - Adicionada interface `DocumentBuilder<T>` com métodos de alto nível apenas
  - Adicionado `LatexDocumentBuilder` implementando o padrão Builder para LaTeX
  - Adicionado `LatexReviewExporter` implementando `ReviewExporter`

  ### Camada web
  - Adicionados `RestfulExportReviewPresenter` e `DownloadableReviewPresenter`
  - Refatorado `DownloadableProtocolPresenter` para usar `buildDownloadResponse` compartilhado
  - Adicionado endpoint `GET /api/v1/systematic-study/{id}/report/exportable-review/{format}?downloadable={bool}`

  ### Testes
  - Testes unitários para `ExportReviewServiceImpl`
  - Testes de integração para o novo endpoint em `ReportControllerTest`
