### PR TITLE
feat(review): introduce collaborator authorization and role management

### DIFF
--- a/review/src/main/kotlin/br/all/application/review/create/AddCollaboratorService.kt
+++ b/review/src/main/kotlin/br/all/application/review/create/AddCollaboratorService.kt
@@ -34,7 +34,7 @@ class AddCollaboratorService(
         systematicStudy.collaborators += researcherId
         systematicStudyRepository.saveOrUpdate(systematicStudy)
 
-        val collaborator = CollaboratorDto(systematicStudyId, researcherId, user.name, user.email, role.toString())
+        val collaborator = CollaboratorDto(researcherId, systematicStudyId, user.name, user.email, role.toString())
         collaboratorRepository.saveOrUpdate(collaborator)
     }
 }

--- a/review/src/main/kotlin/br/all/application/review/create/CreateSystematicStudyServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/review/create/CreateSystematicStudyServiceImpl.kt
@@ -5,16 +5,22 @@ import br.all.application.protocol.repository.toDto
 import br.all.application.user.CredentialsService
 import br.all.application.review.create.CreateSystematicStudyService.RequestModel
 import br.all.application.review.create.CreateSystematicStudyService.ResponseModel
+import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.review.repository.fromRequestModel
 import br.all.application.review.repository.toDto
-import br.all.application.shared.presenter.prepareIfUnauthorized
 import br.all.domain.model.protocol.Protocol
+import br.all.domain.model.review.Collaborator
 import br.all.domain.model.review.SystematicStudy
+import br.all.domain.model.review.SystematicStudyId
 import br.all.domain.model.review.toSystematicStudyId
 import br.all.domain.services.UuidGeneratorService
 import br.all.domain.shared.exception.EntityNotFoundException
+import br.all.domain.shared.exception.UnauthenticatedUserException
 import br.all.domain.shared.exception.UnauthorizedUserException
+import br.all.domain.shared.user.Email
+import br.all.domain.shared.user.ResearcherId
+import br.all.domain.shared.user.Role
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -24,11 +30,12 @@ class CreateSystematicStudyServiceImpl(
     private val protocolRepository: ProtocolRepository,
     private val uuidGeneratorService: UuidGeneratorService,
     private val credentialsService: CredentialsService,
+    private val collaboratorRepository: CollaboratorRepository,
 ) : CreateSystematicStudyService {
     
     @Transactional
     override fun create(presenter: CreateSystematicStudyPresenter, request: RequestModel) {
-        val userCredentials = credentialsService.loadEnabledState(request.userId)
+        val userCredentials = credentialsService.loadEnabledCredentialsById(request.userId)
         if (userCredentials == null) {
             presenter.prepareFailView(
                 EntityNotFoundException("User not found")
@@ -42,18 +49,29 @@ class CreateSystematicStudyServiceImpl(
                 )
             }
         }
-        val user = userCredentials?.toUser()
-        presenter.prepareIfUnauthorized(user)
+
+        if (userCredentials == null) {
+            presenter.prepareFailView(UnauthenticatedUserException("Current user is not authenticated."))
+        }
 
         if (presenter.isDone()) return
 
         val generatedId = uuidGeneratorService.next()
         val systematicStudy = SystematicStudy.fromRequestModel(generatedId, request)
+
+        val collaborator = Collaborator(
+            ResearcherId(request.userId),
+            SystematicStudyId(generatedId),
+            userCredentials!!.name,
+            Email(userCredentials.email),
+            Role.OWNER)
+
+        collaboratorRepository.saveOrUpdate(collaborator.toDto())
         systematicStudyRepository.saveOrUpdate(systematicStudy.toDto())
 
         val protocol = Protocol.write(generatedId.toSystematicStudyId(), emptySet()).build()
         protocolRepository.saveOrUpdate(protocol.toDto())
 
-        presenter.prepareSuccessView(ResponseModel(user!!.id.value(), generatedId))
+        presenter.prepareSuccessView(ResponseModel(userCredentials.id, generatedId))
     }
 }

--- a/review/src/main/kotlin/br/all/application/review/create/RespondInvitationServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/review/create/RespondInvitationServiceImpl.kt
@@ -36,7 +36,7 @@ open class RespondInvitationServiceImpl(
         }
 
         try {
-            addCollaboratorService.addCollaborator(token.researcherId, token.systematicStudyId, Role.COLLABORATOR)
+            addCollaboratorService.addCollaborator(token.researcherId, token.systematicStudyId, Role.EDITOR)
 
             token.status = TokenStatus.CONCLUIDO
             token.expiration = LocalDateTime.now().plusDays(1)

--- a/review/src/main/kotlin/br/all/application/review/repository/CollaboratorMapper.kt
+++ b/review/src/main/kotlin/br/all/application/review/repository/CollaboratorMapper.kt
@@ -10,7 +10,7 @@ fun Collaborator.toDto() = CollaboratorDto(
     id.value(),
     systematicStudyId.value(),
     username,
-    email.toString(),
+    email.email,
     role.toString(),
 )
 

--- a/review/src/main/kotlin/br/all/application/review/repository/CollaboratorRepository.kt
+++ b/review/src/main/kotlin/br/all/application/review/repository/CollaboratorRepository.kt
@@ -10,4 +10,6 @@ interface CollaboratorRepository {
     fun existsById(id: UUID) : Boolean
 
     fun existsByResearcherIdAndSystematicStudyId(id: UUID, systematicStudyId: UUID): Boolean
+
+    fun findByResearcherIdAndSystematicStudyId(id: UUID, systematicStudyId: UUID): CollaboratorDto?
 }

--- a/review/src/main/kotlin/br/all/application/review/update/presenter/UpdateResearcherRolePresenter.kt
+++ b/review/src/main/kotlin/br/all/application/review/update/presenter/UpdateResearcherRolePresenter.kt
@@ -1,0 +1,6 @@
+package br.all.application.review.update.presenter
+
+import br.all.application.review.update.services.UpdateResearcherRoleService.ResponseModel
+import br.all.domain.shared.presenter.GenericPresenter
+
+interface UpdateResearcherRolePresenter : GenericPresenter<ResponseModel>

--- a/review/src/main/kotlin/br/all/application/review/update/services/UpdateResearcherRoleService.kt
+++ b/review/src/main/kotlin/br/all/application/review/update/services/UpdateResearcherRoleService.kt
@@ -1,0 +1,21 @@
+package br.all.application.review.update.services
+
+import br.all.application.review.update.presenter.UpdateResearcherRolePresenter
+import br.all.domain.shared.user.Role
+import java.util.*
+
+interface UpdateResearcherRoleService {
+    fun update(presenter: UpdateResearcherRolePresenter, request: RequestModel)
+
+    data class RequestModel(
+        val userId: UUID,
+        val systematicStudyId: UUID,
+        val researcherId: UUID,
+        val role: Role,
+    )
+
+    data class ResponseModel(
+        val researcherId: UUID,
+        val role: Role,
+    )
+}

--- a/review/src/main/kotlin/br/all/application/review/update/services/UpdateResearcherRoleServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/review/update/services/UpdateResearcherRoleServiceImpl.kt
@@ -1,0 +1,45 @@
+package br.all.application.review.update.services
+
+import br.all.application.review.repository.CollaboratorRepository
+import br.all.application.review.update.presenter.UpdateResearcherRolePresenter
+import br.all.application.review.update.services.UpdateResearcherRoleService.RequestModel
+import br.all.application.review.update.services.UpdateResearcherRoleService.ResponseModel
+import br.all.application.shared.service.AuthorizationService
+import br.all.domain.shared.exception.EntityNotFoundException
+import br.all.domain.shared.user.Role
+
+class UpdateResearcherRoleServiceImpl(
+    private val collaboratorRepository: CollaboratorRepository,
+    private val authorizationService: AuthorizationService
+    ): UpdateResearcherRoleService {
+    private val assignableRoles = setOf(Role.VIEWER, Role.REVIEWER, Role.EDITOR)
+
+    override fun update(
+        presenter: UpdateResearcherRolePresenter,
+        request: RequestModel
+    ) {
+        authorizationService.authorize(presenter, request.userId, request.systematicStudyId, setOf(Role.OWNER))
+        if (presenter.isDone()) return
+
+        if (request.role !in assignableRoles) {
+            presenter.prepareFailView(IllegalArgumentException("Role ${request.role} cannot be assigned to a collaborator."))
+            return
+        }
+
+        if (request.researcherId == request.userId) {
+            presenter.prepareFailView(IllegalArgumentException("You cannot self switch your own role"))
+            return
+        }
+
+        val researcher = collaboratorRepository.findByResearcherIdAndSystematicStudyId(request.researcherId, request.systematicStudyId)
+        if(researcher == null) {
+            presenter.prepareFailView(EntityNotFoundException("There is no collaborator of id ${request.researcherId} on this systematic study."))
+            return
+        }
+
+        researcher.role = request.role.toString()
+        collaboratorRepository.saveOrUpdate(researcher)
+
+        presenter.prepareSuccessView(ResponseModel(request.researcherId, request.role))
+    }
+}

--- a/review/src/main/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImpl.kt
@@ -6,11 +6,9 @@ import br.all.application.review.update.presenter.UpdateSystematicStudyPresenter
 import br.all.application.review.update.services.UpdateSystematicStudyService.RequestModel
 import br.all.application.review.update.services.UpdateSystematicStudyService.ResponseModel
 import br.all.application.shared.service.AuthorizationService
-import br.all.application.user.CredentialsService
 
 class UpdateSystematicStudyServiceImpl(
     private val repository: SystematicStudyRepository,
-    private val credentialsService: CredentialsService,
     private val authorizationService: AuthorizationService,
 ) : UpdateSystematicStudyService {
     override fun update(presenter: UpdateSystematicStudyPresenter, request: RequestModel) {

--- a/review/src/main/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImpl.kt
+++ b/review/src/main/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImpl.kt
@@ -1,43 +1,42 @@
 package br.all.application.review.update.services
 
 import br.all.application.review.repository.SystematicStudyRepository
-import br.all.application.review.repository.fromDto
 import br.all.application.review.repository.toDto
 import br.all.application.review.update.presenter.UpdateSystematicStudyPresenter
 import br.all.application.review.update.services.UpdateSystematicStudyService.RequestModel
 import br.all.application.review.update.services.UpdateSystematicStudyService.ResponseModel
-import br.all.domain.shared.exception.EntityNotFoundException
-import br.all.application.shared.presenter.prepareIfUnauthorized
+import br.all.application.shared.service.AuthorizationService
 import br.all.application.user.CredentialsService
-import br.all.domain.model.review.SystematicStudy
 
 class UpdateSystematicStudyServiceImpl(
     private val repository: SystematicStudyRepository,
     private val credentialsService: CredentialsService,
+    private val authorizationService: AuthorizationService,
 ) : UpdateSystematicStudyService {
     override fun update(presenter: UpdateSystematicStudyPresenter, request: RequestModel) {
-        val userId = request.userId
+        val context = authorizationService.authorize(
+            presenter,
+            request.userId,
+            request.systematicStudy
+        )
 
-        val user = credentialsService.loadCredentials(userId)?.toUser()
-        presenter.prepareIfUnauthorized(user)
-        if (presenter.isDone()) return
-
-        val systematicStudy = request.systematicStudy
-
-        val dto = repository.findById(systematicStudy)
-        if(dto == null) {
-            val message =
-                "There is no systematic study of id ${request.systematicStudy} or systematic study of id ${request.systematicStudy}."
-            presenter.prepareFailView(EntityNotFoundException(message))
+        if (presenter.isDone()){
             return
         }
-        val updated = SystematicStudy.fromDto(dto).apply {
+
+        context!!
+
+        val systematicStudy = context.systematicStudy
+        val original = systematicStudy.toDto()
+
+        val updated = systematicStudy.apply {
             title = request.title ?: title
             description = request.description ?: description
             objectives = request.objectives ?: objectives
         }.toDto()
 
-        if (updated != dto) repository.saveOrUpdate(updated)
-        presenter.prepareSuccessView(ResponseModel(userId, systematicStudy))
+        if (updated != original) repository.saveOrUpdate(updated)
+
+        presenter.prepareSuccessView(ResponseModel(request.userId, request.systematicStudy))
     }
 }

--- a/review/src/main/kotlin/br/all/application/shared/presenter/PreconditionCheckerNEW.kt
+++ b/review/src/main/kotlin/br/all/application/shared/presenter/PreconditionCheckerNEW.kt
@@ -10,7 +10,6 @@ import br.all.domain.shared.user.Role.EDITOR
 import br.all.domain.model.review.SystematicStudy
 import br.all.domain.shared.presenter.GenericPresenter
 
-
 fun GenericPresenter<*>.prepareIfFailsPreconditions(
     user: Researcher?,
     systematicStudy: SystematicStudy?,
@@ -26,10 +25,8 @@ fun GenericPresenter<*>.prepareIfFailsPreconditions(
         return
     }
 
-    if (allowedRoles.contains(ADMIN) && existingUser.roles.contains(ADMIN)) return
-
     if (!systematicStudy.collaborators.contains(existingUser.id))
-        this.prepareFailView(UnauthorizedUserException("User of id $existingUser can not perform this action."))
+        this.prepareFailView(UnauthorizedUserException("User of id ${existingUser.id} can not perform this action."))
 }
 
 
@@ -41,6 +38,11 @@ fun GenericPresenter<*>.prepareIfUnauthorized(
         prepareFailView(UnauthenticatedUserException("Current user is not authenticated."))
         return
     }
+
+    if (ADMIN in user.roles) {
+        return
+    }
+
     if (hasAnyOfRequiredRoles(user, allowedRoles)) {
         val message = "Authenticated user ${user.id} has none of required roles: ${allowedRoles.joinToString()}"
         prepareFailView(UnauthorizedUserException(message))

--- a/review/src/main/kotlin/br/all/application/shared/presenter/PreconditionCheckerNEW.kt
+++ b/review/src/main/kotlin/br/all/application/shared/presenter/PreconditionCheckerNEW.kt
@@ -6,7 +6,7 @@ import br.all.domain.shared.exception.UnauthorizedUserException
 import br.all.domain.shared.user.Researcher
 import br.all.domain.shared.user.Role
 import br.all.domain.shared.user.Role.ADMIN
-import br.all.domain.shared.user.Role.COLLABORATOR
+import br.all.domain.shared.user.Role.EDITOR
 import br.all.domain.model.review.SystematicStudy
 import br.all.domain.shared.presenter.GenericPresenter
 
@@ -14,7 +14,7 @@ import br.all.domain.shared.presenter.GenericPresenter
 fun GenericPresenter<*>.prepareIfFailsPreconditions(
     user: Researcher?,
     systematicStudy: SystematicStudy?,
-    allowedRoles: Set<Role> = setOf(COLLABORATOR)
+    allowedRoles: Set<Role> = setOf(EDITOR)
 ) {
     this.prepareIfUnauthorized(user, allowedRoles)
     if (this.isDone()) return
@@ -35,7 +35,7 @@ fun GenericPresenter<*>.prepareIfFailsPreconditions(
 
 fun GenericPresenter<*>.prepareIfUnauthorized(
     user: Researcher?,
-    allowedRoles: Set<Role> = setOf(COLLABORATOR)
+    allowedRoles: Set<Role> = setOf(EDITOR)
 ) {
     if (user == null) {
         prepareFailView(UnauthenticatedUserException("Current user is not authenticated."))

--- a/review/src/main/kotlin/br/all/application/shared/service/AuthorizationService.kt
+++ b/review/src/main/kotlin/br/all/application/shared/service/AuthorizationService.kt
@@ -1,0 +1,67 @@
+package br.all.application.shared.service
+
+import br.all.application.review.repository.CollaboratorRepository
+import br.all.application.review.repository.SystematicStudyRepository
+import br.all.application.review.repository.fromDto
+import br.all.application.shared.presenter.prepareIfFailsPreconditions
+import br.all.application.user.CredentialsService
+import br.all.domain.model.review.SystematicStudy
+import br.all.domain.shared.presenter.GenericPresenter
+import br.all.domain.shared.user.Researcher
+import br.all.domain.shared.user.Role
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class AuthorizationService(
+    private val credentialsService: CredentialsService,
+    private val systematicStudyRepository: SystematicStudyRepository,
+    private val collaboratorRepository: CollaboratorRepository
+) {
+
+    data class AuthorizationContext(
+        val researcher: Researcher,
+        val systematicStudy: SystematicStudy
+    )
+
+    fun authorize(
+        presenter: GenericPresenter<*>,
+        researcherId: UUID,
+        systematicStudyId: UUID,
+        allowedRoles: Set<Role> = setOf(Role.EDITOR)
+    ): AuthorizationContext? {
+
+        val researcher = credentialsService.loadCredentials(researcherId)?.toUser()
+        val systematicStudyDto = systematicStudyRepository.findById(systematicStudyId)
+        val systematicStudy = systematicStudyDto?.let { SystematicStudy.fromDto(it) }
+
+        if (researcher != null &&
+            systematicStudy != null &&
+            !researcher.roles.contains(Role.ADMIN))
+        {
+            val collaborator = collaboratorRepository.findByResearcherIdAndSystematicStudyId(
+                researcherId,
+                systematicStudyId
+            )
+
+            if (collaborator != null) {
+                researcher.roles += Role.valueOf(collaborator.role)
+            }
+        }
+
+        presenter.prepareIfFailsPreconditions(
+            researcher,
+            systematicStudy,
+            allowedRoles
+        )
+
+        if (presenter.isDone()) {
+            return null
+        }
+
+        return AuthorizationContext(
+            researcher = researcher!!,
+            systematicStudy = systematicStudy!!
+        )
+    }
+}

--- a/review/src/main/kotlin/br/all/application/user/CredentialsService.kt
+++ b/review/src/main/kotlin/br/all/application/user/CredentialsService.kt
@@ -20,10 +20,10 @@ interface CredentialsService {
     data class ResponseModel(val id: UUID, val username: String, val roles: Set<String>){
         fun toUser() : Researcher {
             val researcherId = ResearcherId(id)
-            val userRoles = roles.toMutableSet()
+            val userRoles = roles
                 .map { if (it == "USER") "EDITOR" else it }
                 .map { Role.valueOf(it) }
-                .toSet()
+                .toMutableSet()
 
             return Researcher(researcherId, username, userRoles)
         }
@@ -32,10 +32,10 @@ interface CredentialsService {
     data class EnabledResponseModel(val id: UUID, val username: String, val roles: Set<String>, val isEnabled : Boolean){
         fun toUser() : Researcher {
             val researcherId = ResearcherId(id)
-            val userRoles = roles.toMutableSet()
+            val userRoles = roles
                 .map { if (it == "USER") "EDITOR" else it }
                 .map { Role.valueOf(it) }
-                .toSet()
+                .toMutableSet()
 
             return Researcher(researcherId, username, userRoles)
         }

--- a/review/src/main/kotlin/br/all/application/user/CredentialsService.kt
+++ b/review/src/main/kotlin/br/all/application/user/CredentialsService.kt
@@ -21,7 +21,7 @@ interface CredentialsService {
         fun toUser() : Researcher {
             val researcherId = ResearcherId(id)
             val userRoles = roles.toMutableSet()
-                .map { if (it == "USER") "COLLABORATOR" else it }
+                .map { if (it == "USER") "EDITOR" else it }
                 .map { Role.valueOf(it) }
                 .toSet()
 
@@ -33,7 +33,7 @@ interface CredentialsService {
         fun toUser() : Researcher {
             val researcherId = ResearcherId(id)
             val userRoles = roles.toMutableSet()
-                .map { if (it == "USER") "COLLABORATOR" else it }
+                .map { if (it == "USER") "EDITOR" else it }
                 .map { Role.valueOf(it) }
                 .toSet()
 

--- a/review/src/main/kotlin/br/all/infrastructure/review/CollaboratorDbMapper.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/review/CollaboratorDbMapper.kt
@@ -4,6 +4,7 @@ import br.all.application.review.repository.CollaboratorDto
 
 
 fun CollaboratorDto.toDocument() = CollaboratorDocument(
+    CollaboratorDocument.buildId(researcherId,systematicStudyId),
     researcherId,
     systematicStudyId,
     username,

--- a/review/src/main/kotlin/br/all/infrastructure/review/CollaboratorDocument.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/review/CollaboratorDocument.kt
@@ -1,13 +1,19 @@
 package br.all.infrastructure.review
 
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.util.*
 
 @Document("collaborator")
 data class CollaboratorDocument(
+    @Id val id: String,
     val researcherId: UUID,
     val systematicStudyId: UUID,
     val username: String,
     val email: String,
     val role: String,
-)
+) {
+    companion object {
+        fun buildId(researcherId: UUID, systematicStudyId: UUID) = "$researcherId:$systematicStudyId"
+    }
+}

--- a/review/src/main/kotlin/br/all/infrastructure/review/CollaboratorRepositoryImpl.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/review/CollaboratorRepositoryImpl.kt
@@ -24,4 +24,10 @@ class CollaboratorRepositoryImpl(
 
     override fun existsByResearcherIdAndSystematicStudyId(id: UUID, systematicStudyId: UUID) =
         innerRepository.existsByResearcherIdAndSystematicStudyId(id, systematicStudyId)
+
+    override fun findByResearcherIdAndSystematicStudyId(
+        id: UUID,
+        systematicStudyId: UUID
+    ) =  innerRepository.findByResearcherIdAndSystematicStudyId(id, systematicStudyId)?.toDto()
+
 }

--- a/review/src/main/kotlin/br/all/infrastructure/review/MongoCollaboratorRepository.kt
+++ b/review/src/main/kotlin/br/all/infrastructure/review/MongoCollaboratorRepository.kt
@@ -5,4 +5,6 @@ import java.util.*
 
 interface MongoCollaboratorRepository: MongoRepository<CollaboratorDocument, UUID>{
     fun existsByResearcherIdAndSystematicStudyId(researcherId: UUID, systematicStudyId: UUID): Boolean
+
+    fun findByResearcherIdAndSystematicStudyId(researcherId: UUID, systematicStudyId: UUID): CollaboratorDocument?
 }

--- a/review/src/test/kotlin/br/all/application/review/create/CreateSystematicStudyServiceImplTest.kt
+++ b/review/src/test/kotlin/br/all/application/review/create/CreateSystematicStudyServiceImplTest.kt
@@ -1,10 +1,10 @@
 package br.all.application.review.create
 
 import br.all.application.protocol.repository.ProtocolRepository
+import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.review.util.TestDataFactory
 import br.all.domain.shared.exception.UnauthenticatedUserException
-import br.all.domain.shared.exception.UnauthorizedUserException
 import br.all.application.user.CredentialsService
 import br.all.application.util.PreconditionCheckerMockingNew
 import br.all.domain.services.UuidGeneratorService
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 class CreateSystematicStudyServiceImplTest {
     @MockK(relaxUnitFun = true)
     private lateinit var systematicStudyRepository: SystematicStudyRepository
+    @MockK(relaxUnitFun = true)
+    private lateinit var collaboratorRepository: CollaboratorRepository
     @MockK(relaxUnitFun = true)
     private lateinit var protocolRepository: ProtocolRepository
     @MockK
@@ -88,19 +90,6 @@ class CreateSystematicStudyServiceImplTest {
 
             verifyOrder {
                 presenter.prepareFailView(any<UnauthenticatedUserException>())
-                presenter.isDone()
-            }
-        }
-
-        @Test
-        fun `should not the researcher be allowed to create a study when unauthorized`() {
-            val request = factory.createRequestModel()
-
-            preconditionCheckerMocking.makeUserUnauthorized()
-            sut.create(presenter, request)
-
-            verifyOrder {
-                presenter.prepareFailView(any<UnauthorizedUserException>())
                 presenter.isDone()
             }
         }

--- a/review/src/test/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImplTest.kt
+++ b/review/src/test/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImplTest.kt
@@ -52,7 +52,6 @@ class UpdateSystematicStudyServiceImplTest {
 
         sut = UpdateSystematicStudyServiceImpl(
             repository,
-            credentialsService,
             authorizationService
         )
 

--- a/review/src/test/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImplTest.kt
+++ b/review/src/test/kotlin/br/all/application/review/update/services/UpdateSystematicStudyServiceImplTest.kt
@@ -1,16 +1,18 @@
 package br.all.application.review.update.services
 
+import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.SystematicStudyDto
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.review.update.presenter.UpdateSystematicStudyPresenter
 import br.all.application.review.util.TestDataFactory
+import br.all.application.shared.service.AuthorizationService
 import br.all.domain.shared.exception.EntityNotFoundException
 import br.all.domain.shared.exception.UnauthenticatedUserException
 import br.all.domain.shared.exception.UnauthorizedUserException
 import br.all.application.user.CredentialsService
 import br.all.application.util.PreconditionCheckerMockingNew
+import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
@@ -24,11 +26,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 class UpdateSystematicStudyServiceImplTest {
     @MockK(relaxUnitFun = true)
     private lateinit var repository: SystematicStudyRepository
+    @MockK(relaxUnitFun = true)
+    private lateinit var collaboratorRepository: CollaboratorRepository
     @MockK
     private lateinit var credentialsService: CredentialsService
     @MockK(relaxed = true)
     private lateinit var presenter: UpdateSystematicStudyPresenter
-    @InjectMockKs
+
+    lateinit var authorizationService: AuthorizationService
     private lateinit var sut: UpdateSystematicStudyServiceImpl
 
     private lateinit var factory: TestDataFactory
@@ -36,6 +41,21 @@ class UpdateSystematicStudyServiceImplTest {
 
     @BeforeEach
     fun setUp() {
+
+        MockKAnnotations.init(this)
+
+        authorizationService = AuthorizationService(
+            credentialsService,
+            repository,
+            collaboratorRepository
+        )
+
+        sut = UpdateSystematicStudyServiceImpl(
+            repository,
+            credentialsService,
+            authorizationService
+        )
+
         factory = TestDataFactory()
         preconditionCheckerMocking = PreconditionCheckerMockingNew(
             presenter,
@@ -43,6 +63,7 @@ class UpdateSystematicStudyServiceImplTest {
             repository,
             factory.researcher,
             factory.systematicStudy,
+            collaboratorRepository
         )
     }
 
@@ -51,7 +72,7 @@ class UpdateSystematicStudyServiceImplTest {
     @DisplayName("When the systematic study is updated")
     inner class WhenTheSystematicStudyIsUpdated {
         @BeforeEach
-        fun setUp() = run { preconditionCheckerMocking.makeEverythingWork() }
+        fun setUp() = run { preconditionCheckerMocking.makeEverythingWorkWithAuthorization() }
 
         @Test
         fun `should only the title be updated`() {
@@ -112,7 +133,7 @@ class UpdateSystematicStudyServiceImplTest {
             val request = factory.updateRequestModel()
             val response = factory.updateResponseModel()
 
-            preconditionCheckerMocking.makeEverythingWork()
+            preconditionCheckerMocking.makeEverythingWorkWithAuthorization()
             every { repository.findById(factory.systematicStudy) } returns dto
 
             sut.update(presenter, request)
@@ -150,7 +171,7 @@ class UpdateSystematicStudyServiceImplTest {
         fun `should prepare fail view if the researcher is unauthorized`() {
             val request = factory.updateRequestModel()
 
-            preconditionCheckerMocking.makeUserUnauthorized()
+            preconditionCheckerMocking.makeUserUnauthorizedWithAuthorization()
             sut.update(presenter, request)
 
             verifyOrder {

--- a/review/src/test/kotlin/br/all/application/util/PreconditionCheckerMockingNew.kt
+++ b/review/src/test/kotlin/br/all/application/util/PreconditionCheckerMockingNew.kt
@@ -27,17 +27,17 @@ class PreconditionCheckerMockingNew(
 
     fun makeEverythingWork() {
         val user = generateUserDto()
-        val userEnabled = generateUserEnabledDto()
+        val userEnabled = generateUserEnabledCredentialsDto()
         mockkStatic(GenericPresenter<*>::prepareIfFailsPreconditions)
         every { credentialsService.loadCredentials(userId) } returns user
-        every { credentialsService.loadEnabledState(userId) } returns userEnabled
+        every { credentialsService.loadEnabledCredentialsById(userId) } returns userEnabled
         every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
         every { presenter.prepareIfFailsPreconditions(any(), any()) } returns Unit
         every { presenter.isDone() } returns false
     }
 
     fun makeUserUnauthenticated() {
-        every { credentialsService.loadEnabledState(userId) } returns null
+        every { credentialsService.loadEnabledCredentialsById(userId) } returns null
         every { credentialsService.loadCredentials(userId) } returns null
         every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
         every { presenter.isDone() } returns true
@@ -45,9 +45,9 @@ class PreconditionCheckerMockingNew(
 
     fun makeUserUnauthorized() {
         val user = generateUnauthorizedUserDto()
-        val userEnabled = generateUnauthorizedUserEnabledDto()
+        val userEnabled = generateUserEnabledCredentialsDto()
         every { credentialsService.loadCredentials(userId) } returns user
-        every { credentialsService.loadEnabledState(userId) } returns userEnabled
+        every { credentialsService.loadEnabledCredentialsById(userId)  } returns userEnabled
         every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
         every { presenter.isDone() } returns true
     }
@@ -137,12 +137,13 @@ class PreconditionCheckerMockingNew(
         objectives
     )
 
-    private fun generateUserEnabledDto(
+    private fun generateUserEnabledCredentialsDto(
         userId: UUID = this.userId,
         userName: String = faker.name.firstName(),
-        userRoles: Set<String> = setOf("COLLABORATOR"),
-        isEnabled: Boolean = true
-    ) = CredentialsService.EnabledResponseModel(userId, userName, userRoles, isEnabled)
+        userCountry: String = faker.address.country(),
+        isEnabled: Boolean = true,
+        email: String = faker.internet.email(),
+    ) = CredentialsService.InformationResponseModel(userId, userName, userCountry, isEnabled, email)
 
 
     private fun generateUserDto(
@@ -156,13 +157,4 @@ class PreconditionCheckerMockingNew(
         userName: String = faker.name.firstName(),
         userRoles: Set<String> = emptySet()
     ) = CredentialsService.ResponseModel(userId, userName, userRoles)
-
-    private fun generateUnauthorizedUserEnabledDto(
-        userId: UUID = this.userId,
-        userName: String = faker.name.firstName(),
-        userRoles: Set<String> = emptySet(),
-        isEnabled: Boolean = true
-    ) = CredentialsService.EnabledResponseModel(userId, userName, userRoles, isEnabled)
-
-
 }

--- a/review/src/test/kotlin/br/all/application/util/PreconditionCheckerMockingNew.kt
+++ b/review/src/test/kotlin/br/all/application/util/PreconditionCheckerMockingNew.kt
@@ -1,6 +1,8 @@
 package br.all.application.util
 
 import br.all.application.question.repository.QuestionRepository
+import br.all.application.review.repository.CollaboratorDto
+import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.SystematicStudyDto
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.domain.shared.exception.EntityNotFoundException
@@ -21,9 +23,11 @@ class PreconditionCheckerMockingNew(
     private val systematicStudyRepository: SystematicStudyRepository,
     private val userId: UUID,
     private val systematicStudyId: UUID,
+    private val collaboratorRepository: CollaboratorRepository? = null
 ) {
     private val faker = Faker()
     private val systematicStudy = generateSystematicStudy()
+    private val collaborator = generateCollaboratorDto()
 
     fun makeEverythingWork() {
         val user = generateUserDto()
@@ -32,6 +36,18 @@ class PreconditionCheckerMockingNew(
         every { credentialsService.loadCredentials(userId) } returns user
         every { credentialsService.loadEnabledCredentialsById(userId) } returns userEnabled
         every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
+        every { presenter.prepareIfFailsPreconditions(any(), any()) } returns Unit
+        every { presenter.isDone() } returns false
+    }
+
+    fun makeEverythingWorkWithAuthorization() {
+        val user = generateUserDto()
+        val userEnabled = generateUserEnabledCredentialsDto()
+        mockkStatic(GenericPresenter<*>::prepareIfFailsPreconditions)
+        every { credentialsService.loadCredentials(userId) } returns user
+        every { credentialsService.loadEnabledCredentialsById(userId) } returns userEnabled
+        every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
+        every { collaboratorRepository?.findByResearcherIdAndSystematicStudyId(userId, systematicStudyId) } returns collaborator
         every { presenter.prepareIfFailsPreconditions(any(), any()) } returns Unit
         every { presenter.isDone() } returns false
     }
@@ -49,6 +65,16 @@ class PreconditionCheckerMockingNew(
         every { credentialsService.loadCredentials(userId) } returns user
         every { credentialsService.loadEnabledCredentialsById(userId)  } returns userEnabled
         every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
+        every { presenter.isDone() } returns true
+    }
+
+    fun makeUserUnauthorizedWithAuthorization() {
+        val user = generateUnauthorizedUserDto()
+        val userEnabled = generateUserEnabledCredentialsDto()
+        every { credentialsService.loadCredentials(userId) } returns user
+        every { credentialsService.loadEnabledCredentialsById(userId)  } returns userEnabled
+        every { systematicStudyRepository.findById(systematicStudyId) } returns systematicStudy
+        every { collaboratorRepository?.findByResearcherIdAndSystematicStudyId(userId, systematicStudyId) } returns null
         every { presenter.isDone() } returns true
     }
 
@@ -151,6 +177,14 @@ class PreconditionCheckerMockingNew(
         userName: String = faker.name.firstName(),
         userRoles: Set<String> = setOf("USER"),
     ) = CredentialsService.ResponseModel(userId, userName, userRoles)
+
+    private fun generateCollaboratorDto(
+        researcherId: UUID = this.userId,
+        systematicStudyId: UUID = this.systematicStudyId,
+        username: String = faker.name.firstName(),
+        email: String = faker.internet.email(),
+        role: String = "OWNER"
+    ) = CollaboratorDto(researcherId, systematicStudyId, username, email, role)
 
     private fun generateUnauthorizedUserDto(
         userId: UUID = this.userId,

--- a/review/src/test/kotlin/br/all/application/util/PreconditionCheckerMockingNew.kt
+++ b/review/src/test/kotlin/br/all/application/util/PreconditionCheckerMockingNew.kt
@@ -149,7 +149,7 @@ class PreconditionCheckerMockingNew(
     private fun generateUserDto(
         userId: UUID = this.userId,
         userName: String = faker.name.firstName(),
-        userRoles: Set<String> = setOf("COLLABORATOR"),
+        userRoles: Set<String> = setOf("USER"),
     ) = CredentialsService.ResponseModel(userId, userName, userRoles)
 
     private fun generateUnauthorizedUserDto(

--- a/shared/src/main/kotlin/br/all/domain/shared/user/Researcher.kt
+++ b/shared/src/main/kotlin/br/all/domain/shared/user/Researcher.kt
@@ -6,5 +6,5 @@ import java.util.UUID
 class Researcher (
     id: ResearcherId,
     val username: String,
-    val roles: Set<Role>
+    val roles: MutableSet<Role>
 ) : Entity<UUID>(id)

--- a/shared/src/main/kotlin/br/all/domain/shared/user/Role.kt
+++ b/shared/src/main/kotlin/br/all/domain/shared/user/Role.kt
@@ -1,7 +1,9 @@
 package br.all.domain.shared.user
 
 enum class Role {
-    COLLABORATOR,
+    VIEWER,
+    REVIEWER,
+    EDITOR,
     OWNER,
     ADMIN
 }

--- a/shared/src/main/kotlin/br/all/domain/shared/user/Role.kt
+++ b/shared/src/main/kotlin/br/all/domain/shared/user/Role.kt
@@ -2,5 +2,6 @@ package br.all.domain.shared.user
 
 enum class Role {
     COLLABORATOR,
+    OWNER,
     ADMIN
 }

--- a/web/src/main/kotlin/br/all/review/controller/SystematicStudyController.kt
+++ b/web/src/main/kotlin/br/all/review/controller/SystematicStudyController.kt
@@ -7,6 +7,7 @@ import br.all.application.review.find.services.FindAllSystematicStudiesService
 import br.all.application.review.find.services.FindAllSystematicStudiesService.FindByOwnerRequest
 import br.all.application.review.find.services.FindSystematicStudyService
 import br.all.application.review.find.services.SearchCollaboratorCandidatesService
+import br.all.application.review.update.services.UpdateResearcherRoleService
 import br.all.application.review.update.services.UpdateSystematicStudyService
 import br.all.review.presenter.RestfulCreateInviteCollaboratorPresenter
 import br.all.review.presenter.RestfulCreateSystematicStudyPresenter
@@ -14,12 +15,14 @@ import br.all.review.presenter.RestfulFindAllSystematicStudiesPresenter
 import br.all.review.presenter.RestfulFindSystematicStudyPresenter
 import br.all.review.presenter.RestfulRespondInvitationPresenter
 import br.all.review.presenter.RestfulSearchCollaboratorCandidatesPresenter
+import br.all.review.presenter.RestfulUpdateResearcherPresenter
 import br.all.review.presenter.RestfulUpdateSystematicStudyPresenter
 import br.all.review.requests.PostRequest
 import br.all.review.requests.PutRequest
 import br.all.review.requests.InviteCollaboratorRequest
 import br.all.review.requests.RespondInvitationRequest
 import br.all.review.requests.SearchCandidatesRequest
+import br.all.review.requests.UpdateRoleRequest
 import br.all.security.service.AuthenticationInfoService
 import br.all.utils.LinksFactory
 import io.swagger.v3.oas.annotations.Operation
@@ -40,6 +43,7 @@ class SystematicStudyController(
     private val findSystematicStudyServiceImpl: FindSystematicStudyService,
     private val findAllSystematicStudiesService: FindAllSystematicStudiesService,
     private val updateSystematicStudyService: UpdateSystematicStudyService,
+    private val updateResearcherRoleService: UpdateResearcherRoleService,
     private val authenticationInfoService: AuthenticationInfoService,
     private val inviteCollaboratorService: InviteCollaboratorService,
     private val respondInvitationService: RespondInvitationService,
@@ -317,6 +321,41 @@ class SystematicStudyController(
         val requestModel = request.toCreateRequestModel(systematicStudyId)
 
         searchCollaboratorCandidatesService.findCandidatesWith(presenter, requestModel)
+        return presenter.responseEntity ?: ResponseEntity<Void>(HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
+    @PutMapping("/{systematicStudyId}/collaborator")
+    @Operation(summary = "Update an existing collaborator role")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Success updating an existing collaborator role",
+                content = [Content(schema = Schema(hidden = true))]),
+            ApiResponse(
+                responseCode = "400",
+                description = "Fail updating an existing collaborator role - invalid systematic study",
+                content = [Content(schema = Schema(hidden = true))]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "Fail updating an existing collaborator role - unauthenticated user",
+                content = [Content(schema = Schema(hidden = true))]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Fail updating an existing collaborator role - unauthorized user",
+                content = [Content(schema = Schema(hidden = true))]
+            ),
+            ApiResponse(responseCode = "404", description = "Fail updating an existing collaborator role - not found",
+                content = [Content(schema = Schema(hidden = true))]),
+        ]
+    )
+    fun updateResearcherRole(@PathVariable systematicStudyId: UUID,
+                              @RequestBody request: UpdateRoleRequest): ResponseEntity<*> {
+        val presenter = RestfulUpdateResearcherPresenter()
+        val userId = authenticationInfoService.getAuthenticatedUserId()
+        val requestModel = request.toUpdateRequestModel(userId, systematicStudyId, request.researcherId, request.role)
+
+        updateResearcherRoleService.update(presenter, requestModel)
         return presenter.responseEntity ?: ResponseEntity<Void>(HttpStatus.INTERNAL_SERVER_ERROR)
     }
 }

--- a/web/src/main/kotlin/br/all/review/controller/SystematicStudyServicesConfiguration.kt
+++ b/web/src/main/kotlin/br/all/review/controller/SystematicStudyServicesConfiguration.kt
@@ -8,6 +8,7 @@ import br.all.application.review.create.RespondInvitationServiceImpl
 import br.all.application.review.find.services.FindAllSystematicStudiesServiceImpl
 import br.all.application.review.find.services.FindSystematicStudyServiceImpl
 import br.all.application.review.find.services.SearchCollaboratorCandidatesServiceImpl
+import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.CollaboratorTokenRepository
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.review.update.services.UpdateSystematicStudyServiceImpl
@@ -24,11 +25,13 @@ class SystematicStudyServicesConfiguration {
         protocolRepository: ProtocolRepository,
         uuidGeneratorService: UuidGeneratorService,
         credentialsService: CredentialsService,
+        collaboratorRepository: CollaboratorRepository
     ) = CreateSystematicStudyServiceImpl(
         systematicStudyRepository,
         protocolRepository,
         uuidGeneratorService,
         credentialsService,
+        collaboratorRepository
     )
 
     @Bean

--- a/web/src/main/kotlin/br/all/review/controller/SystematicStudyServicesConfiguration.kt
+++ b/web/src/main/kotlin/br/all/review/controller/SystematicStudyServicesConfiguration.kt
@@ -12,6 +12,7 @@ import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.CollaboratorTokenRepository
 import br.all.application.review.repository.SystematicStudyRepository
 import br.all.application.review.update.services.UpdateSystematicStudyServiceImpl
+import br.all.application.shared.service.AuthorizationService
 import br.all.application.user.SearchResearchesService
 import br.all.domain.services.UuidGeneratorService
 import org.springframework.context.annotation.Bean
@@ -50,7 +51,8 @@ class SystematicStudyServicesConfiguration {
     fun updateSystematicStudyService(
         systematicStudyRepository: SystematicStudyRepository,
         credentialsService: CredentialsService,
-    ) = UpdateSystematicStudyServiceImpl(systematicStudyRepository, credentialsService)
+        authorizationService: AuthorizationService,
+    ) = UpdateSystematicStudyServiceImpl(systematicStudyRepository, credentialsService, authorizationService)
 
     @Bean
     fun respondInvitationService(

--- a/web/src/main/kotlin/br/all/review/controller/SystematicStudyServicesConfiguration.kt
+++ b/web/src/main/kotlin/br/all/review/controller/SystematicStudyServicesConfiguration.kt
@@ -11,6 +11,7 @@ import br.all.application.review.find.services.SearchCollaboratorCandidatesServi
 import br.all.application.review.repository.CollaboratorRepository
 import br.all.application.review.repository.CollaboratorTokenRepository
 import br.all.application.review.repository.SystematicStudyRepository
+import br.all.application.review.update.services.UpdateResearcherRoleServiceImpl
 import br.all.application.review.update.services.UpdateSystematicStudyServiceImpl
 import br.all.application.shared.service.AuthorizationService
 import br.all.application.user.SearchResearchesService
@@ -50,9 +51,8 @@ class SystematicStudyServicesConfiguration {
     @Bean
     fun updateSystematicStudyService(
         systematicStudyRepository: SystematicStudyRepository,
-        credentialsService: CredentialsService,
         authorizationService: AuthorizationService,
-    ) = UpdateSystematicStudyServiceImpl(systematicStudyRepository, credentialsService, authorizationService)
+    ) = UpdateSystematicStudyServiceImpl(systematicStudyRepository, authorizationService)
 
     @Bean
     fun respondInvitationService(
@@ -66,4 +66,10 @@ class SystematicStudyServicesConfiguration {
         systematicStudyRepository: SystematicStudyRepository,
         collaboratorTokenRepository: CollaboratorTokenRepository,
     ) = SearchCollaboratorCandidatesServiceImpl(searchResearchesService,systematicStudyRepository, collaboratorTokenRepository)
+
+    @Bean
+    fun updateResearcherRoleService(
+        collaboratorRepository: CollaboratorRepository,
+        authorizationService: AuthorizationService,
+    ) = UpdateResearcherRoleServiceImpl(collaboratorRepository, authorizationService)
 }

--- a/web/src/main/kotlin/br/all/review/presenter/RestfulUpdateResearcherPresenter.kt
+++ b/web/src/main/kotlin/br/all/review/presenter/RestfulUpdateResearcherPresenter.kt
@@ -1,0 +1,29 @@
+package br.all.review.presenter
+
+import br.all.application.review.update.presenter.UpdateResearcherRolePresenter
+import br.all.application.review.update.services.UpdateResearcherRoleService.ResponseModel
+import br.all.domain.shared.user.Role
+import br.all.shared.error.createErrorResponseFrom
+import org.springframework.hateoas.RepresentationModel
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.util.*
+
+class RestfulUpdateResearcherPresenter: UpdateResearcherRolePresenter {
+    var responseEntity: ResponseEntity<*>? = null
+
+    override fun prepareSuccessView(response: ResponseModel) {
+        val restfulResponse = ViewModel(response.researcherId, response.role)
+
+        responseEntity = ResponseEntity.status(HttpStatus.OK).body(restfulResponse)
+    }
+
+    override fun prepareFailView(throwable: Throwable) = run { responseEntity = createErrorResponseFrom(throwable) }
+
+    override fun isDone() = responseEntity != null
+
+    private data class ViewModel(
+        val researcherId: UUID,
+        val role: Role,
+    ): RepresentationModel<ViewModel>()
+}

--- a/web/src/main/kotlin/br/all/review/requests/UpdateRoleRequest.kt
+++ b/web/src/main/kotlin/br/all/review/requests/UpdateRoleRequest.kt
@@ -1,0 +1,10 @@
+package br.all.review.requests
+
+import br.all.application.review.update.services.UpdateResearcherRoleService
+import br.all.domain.shared.user.Role
+import java.util.UUID
+
+data class UpdateRoleRequest(val researcherId: UUID, val role: Role) {
+    fun toUpdateRequestModel(userId: UUID, systematicStudyId: UUID, researcherId: UUID, role: Role) =
+        UpdateResearcherRoleService.RequestModel(userId, systematicStudyId, researcherId, role)
+}

--- a/web/src/test/kotlin/br/all/review/controller/SystematicStudyControllerTest.kt
+++ b/web/src/test/kotlin/br/all/review/controller/SystematicStudyControllerTest.kt
@@ -121,13 +121,6 @@ class SystematicStudyControllerTest @Autowired constructor(
         }
 
         @Test
-        fun `should not create study when user is unauthorized`(){
-            testHelperService.testForUnauthorizedUser(mockMvc,
-                post(postUrl()).content(factory.createValidPostRequest())
-            )
-        }
-
-        @Test
         fun `should not create study when user is unauthenticated`(){
             testHelperService.testForUnauthenticatedUser(mockMvc,
                 post(postUrl()).content(factory.createValidPostRequest()),


### PR DESCRIPTION
## What was done

- Introduced a centralized `AuthorizationService` for review access.
- Restricted review updates to authorized collaborators and administrators.
- Added researcher role management endpoint.
- Included the review owner in the collaborator collection on review creation.
- Fixed collaborator parameter ordering.
- Updated collaborator role definitions.
- Refactored authorization-related tests and helpers.